### PR TITLE
skill: minor fixes — config review rule + OpenAI API gotcha

### DIFF
--- a/tentacular-skill/references/agent-workflow.md
+++ b/tentacular-skill/references/agent-workflow.md
@@ -328,3 +328,11 @@ for remediation steps.
    behavior against contract declarations. Direct
    `ctx.fetch()` or `ctx.secrets` usage is flagged
    as a contract violation. Use `ctx.dependency()`.
+
+10. **OpenAI `max_completion_tokens` vs `max_tokens`**:
+    Newer OpenAI models (gpt-5 and later) require
+    `max_completion_tokens` in the request body. The
+    legacy `max_tokens` parameter returns a 400 error.
+    Always use `max_completion_tokens` for gpt-5+.
+    See [Node Development](node-development.md) for
+    the full pattern.

--- a/tentacular-skill/references/node-development.md
+++ b/tentacular-skill/references/node-development.md
@@ -387,3 +387,37 @@ export default async function run(ctx: Context, input: unknown): Promise<unknown
 ```
 
 **Important:** `@db/postgres` auto-parses JSONB columns to JavaScript objects. Do not call `JSON.parse()` on values from JSONB columns -- they are already objects, and double-parsing will throw an error or produce incorrect results.
+
+## LLM API Patterns
+
+### OpenAI Chat Completions
+
+When calling OpenAI's chat completions API from nodes:
+
+```typescript
+const openai = ctx.dependency("openai-api");
+const resp = await globalThis.fetch("https://api.openai.com/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${openai.secret}`,
+  },
+  body: JSON.stringify({
+    model: "gpt-5.2",
+    messages: [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Summarize this data..." },
+    ],
+    temperature: 0.3,
+    max_completion_tokens: 2000,
+  }),
+});
+```
+
+**Critical: `max_completion_tokens` vs `max_tokens`.**
+Newer OpenAI models (gpt-5 and later) require
+`max_completion_tokens`. The legacy `max_tokens`
+parameter returns a 400 error on these models. Always
+use `max_completion_tokens` for gpt-5, gpt-5.1,
+gpt-5.2, and newer. The older `max_tokens` only works
+with legacy models (gpt-4, gpt-4-turbo, gpt-3.5).


### PR DESCRIPTION
Two skill documentation improvements:

## Changes

### 1. Require agent to show config when agent-authored
- Added to **agent-workflow.md** Step 5 (Pre-Validate): agents must display config files to the user before proceeding when they create or modify them
- Added as **Non-Negotiable Rule #6**: never silently use agent-authored configuration

### 2. Document OpenAI `max_completion_tokens` vs `max_tokens`
- **node-development.md**: New "LLM API Patterns" section with code example and explanation
- **agent-workflow.md**: Added as Common Gotcha #10

### Context
Both issues were discovered during a live test deployment of a new `ai-news-roundup` workflow on the agensys2 cluster. The config rule ensures users can verify registry, namespace, image, and environment settings. The OpenAI gotcha prevents a 400 error when using gpt-5+ models with the legacy `max_tokens` parameter.