### PR TITLE
skill: document tentacles — production workflows live outside the repo

### DIFF
--- a/tentacular-skill/SKILL.md
+++ b/tentacular-skill/SKILL.md
@@ -1,5 +1,45 @@
 # Tentacular
 
+## Tentacles: Production Workflow Best Practice
+
+Production workflows (called **tentacles**) MUST be stored
+outside the tentacular repository. The repo contains only
+the tool (CLI + engine), skill, and example workflows.
+Real workflows with secrets, credentials, and
+production-specific configuration belong in a separate
+local directory.
+
+**Recommended layout:**
+
+```
+~/workspace/tentacles/
+  ai-news-roundup/
+    workflow.yaml
+    .secrets.yaml        # NEVER committed to any repo
+    .secrets.yaml.example
+    nodes/
+    tests/
+  uptime-prober/
+    ...
+```
+
+**Why separate?**
+
+- The tentacular repo is public — secrets and production
+  configs must never end up there
+- Workflows are operational artifacts, not source code
+  for the tool itself
+- `example-workflows/` in the repo are reference
+  implementations only — copy them to your tentacles
+  directory to customize and deploy
+
+**When building a new workflow**, always create it in the
+tentacles directory, not in the repo. Use
+`example-workflows/` as templates if helpful, but the
+working copy lives in tentacles.
+
+---
+
 Tentacular is a *secure* workflow build and execution
 system designed for AI agents. It's purpose is to allow
 an AI agent (you) to easily build repeatable and durable

--- a/tentacular-skill/references/agent-workflow.md
+++ b/tentacular-skill/references/agent-workflow.md
@@ -6,6 +6,31 @@ testing tentacular workflows. All commands support
 messages go to stderr and only the JSON envelope goes
 to stdout.
 
+## Tentacles: Where Production Workflows Live
+
+Production workflows (**tentacles**) are stored outside
+the tentacular repo in a dedicated local directory (e.g.,
+`~/workspace/tentacles/<workflow-name>/`). The repo's
+`example-workflows/` directory contains reference
+implementations only — never deploy directly from it.
+
+When creating a new workflow, always scaffold it in the
+tentacles directory. Copy from `example-workflows/` as
+a starting template if useful, but the working copy
+belongs in tentacles. Secrets (`.secrets.yaml`) are kept
+alongside the workflow and must never be committed to
+any repository.
+
+All `tntc` commands accept a path argument and work
+identically whether the workflow is inside or outside
+the repo:
+
+```bash
+tntc validate ~/workspace/tentacles/my-workflow
+tntc test ~/workspace/tentacles/my-workflow
+tntc deploy ~/workspace/tentacles/my-workflow --env prod
+```
+
 ## Develop a Plan in Advance for New or Updated Workflows
 
 Before writing or changing workflow code, the agent MUST run a


### PR DESCRIPTION
## Summary

Production workflows (**tentacles**) should be stored outside the tentacular repo in a dedicated local directory. This PR documents that as a best practice.

## Changes

### SKILL.md
- Added new "Tentacles" section at the top of the file
- Recommended directory layout (`~/workspace/tentacles/`)
- Rationale: public repo, secrets safety, separation of tool vs operational artifacts

### references/agent-workflow.md
- Added "Tentacles: Where Production Workflows Live" section before the planning guide
- Agents must create new workflows in the tentacles directory, not in the repo
- Confirms `tntc` commands work identically with external workflow paths

## Context
Discovered during a live deployment session — ai-news-roundup was initially built inside `example-workflows/` and had to be moved out. This codifies the lesson.