### PR TITLE
fix: skill tentacles directory guidance and running workflow query pattern

### DIFF
--- a/tentacular-skill/SKILL.md
+++ b/tentacular-skill/SKILL.md
@@ -51,23 +51,22 @@ deployed workflows, pass the `KUBECONFIG` and namespace
 explicitly:
 
 ```bash
-# Dev environment
-KUBECONFIG=~/dev-secrets/kubeconfigs/agensys2.kubeconfig \
-  tntc list -n tentacular-dev
+# Dev environment (kubeconfig from ~/.tentacular/config.yaml env.dev.kubeconfig)
+KUBECONFIG=<env.dev.kubeconfig> tntc list -n <env.dev.namespace>
 
 # Prod environment
-KUBECONFIG=~/dev-secrets/kubeconfigs/agensys2.kubeconfig \
-  tntc list -n tentacular-prod
+KUBECONFIG=<env.prod.kubeconfig> tntc list -n <env.prod.namespace>
 ```
+
+The kubeconfig path and namespace for each environment come from
+`~/.tentacular/config.yaml` (or `.tentacular/config.yaml`).
+Check that file for the values to use.
 
 Similarly for status, logs, run, undeploy:
 
 ```bash
-KUBECONFIG=~/dev-secrets/kubeconfigs/agensys2.kubeconfig \
-  tntc status ai-news-roundup -n tentacular-prod
-
-KUBECONFIG=~/dev-secrets/kubeconfigs/agensys2.kubeconfig \
-  tntc logs ai-news-roundup -n tentacular-prod
+KUBECONFIG=<env.prod.kubeconfig> tntc status <workflow-name> -n <env.prod.namespace>
+KUBECONFIG=<env.prod.kubeconfig> tntc logs   <workflow-name> -n <env.prod.namespace>
 ```
 
 The `--env` flag is only supported on `tntc deploy` and


### PR DESCRIPTION
## Summary

Two skill gaps found while managing running workflows in production.

### Changes

**1. Tentacles directory — stronger guardrail**
Added an explicit warning against deploying from `example-workflows/`. These are read-only reference implementations. Production workflows (tentacles) must live in `~/workspace/tentacles/`. Includes remediation steps if a workflow was accidentally deployed from the wrong location.

**2. New "Querying Running Workflows" section**
`tntc list`, `tntc status`, `tntc logs`, etc. do **not** support `--env`. The correct pattern is `KUBECONFIG=<path> tntc list -n <namespace>`. The `--env` flag only works on `tntc deploy` and `tntc test --live`. This was causing confusion when trying to inspect what's actually running on a cluster.

**3. Replace hardcoded kubeconfig path with config-file placeholder**
Previous version accidentally included a real local path in the skill examples. Replaced with `<env.prod.kubeconfig>` placeholder referencing `~/.tentacular/config.yaml`.

### Context
- Found during live workflow management session: `ai-news-roundup` was deployed from `example-workflows/` instead of a tentacles directory
- Workflow has since been moved to `~/workspace/tentacles/ai-news-roundup/` and redeployed from there
- `~/.tentacular/config.yaml` promoted to user-level so `--env` works outside the repo directory