### PR TITLE
fix: install engine with tntc binary; fix WEBHOOK_SECRET crash for cron/queue workflows

### DIFF
--- a/engine/main.ts
+++ b/engine/main.ts
@@ -110,22 +110,23 @@ async function main() {
     }
   }
 
-  // Resolve webhook secret: secrets.github.webhook_secret → WEBHOOK_SECRET env
-  const webhookSecret =
-    (secrets["github"] as Record<string, string> | undefined)?.["webhook_secret"] ??
-    Deno.env.get("WEBHOOK_SECRET");
+  // Resolve webhook secret — only read WEBHOOK_SECRET env var when a webhook
+  // trigger is actually declared. Reading Deno.env unconditionally crashes pods
+  // that run without --allow-env (e.g. cron/queue workflows under gVisor).
+  const hasWebhookTrigger = spec.triggers.some((t) => t.type === "webhook");
+  const secretWebhookSecret =
+    (secrets["github"] as Record<string, string> | undefined)?.["webhook_secret"];
+  const webhookSecret = secretWebhookSecret ??
+    (hasWebhookTrigger ? Deno.env.get("WEBHOOK_SECRET") : undefined);
 
   if (webhookSecret) {
     console.log("  Webhook secret: configured");
-  } else {
-    const hasWebhookTrigger = spec.triggers.some((t) => t.type === "webhook");
-    if (hasWebhookTrigger) {
-      console.warn(
-        "  WARNING: Webhook trigger configured but no webhook secret found. " +
-          "Set secrets.github.webhook_secret or WEBHOOK_SECRET env var. " +
-          "Signature validation will be SKIPPED — do not use in production.",
-      );
-    }
+  } else if (hasWebhookTrigger) {
+    console.warn(
+      "  WARNING: Webhook trigger configured but no webhook secret found. " +
+        "Set secrets.github.webhook_secret or WEBHOOK_SECRET env var. " +
+        "Signature validation will be SKIPPED — do not use in production.",
+    );
   }
 
   // Start HTTP server

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-# Install tntc — the Tentacular CLI
+# Install tntc — the Tentacular CLI + Deno engine
 # Usage: curl -fsSL https://raw.githubusercontent.com/randybias/tentacular/main/install.sh | sh
 set -e
 
 GITHUB_REPO="randybias/tentacular"
 BINARY="tntc"
 : ${TNTC_INSTALL_DIR:="$HOME/.local/bin"}
+: ${TNTC_ENGINE_DIR:="$HOME/.tentacular/engine"}
 : ${TNTC_VERSION:=""}
 
 _fetch() {
@@ -39,26 +40,59 @@ _stable_version() {
     _fetch "https://raw.githubusercontent.com/${GITHUB_REPO}/main/stable.txt"
 }
 
+_install_engine() {
+    VERSION="$1"
+    # Strip leading 'v' for the tarball directory name (v0.1.2 → 0.1.2)
+    VERSION_CLEAN="${VERSION#v}"
+    TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/tags/${VERSION}.tar.gz"
+
+    echo "Installing engine ${VERSION}..."
+    mkdir -p "${TNTC_ENGINE_DIR}"
+
+    # Download source tarball and extract only the engine/ subdirectory.
+    # --strip-components=2 removes 'tentacular-<ver>/engine/' leaving bare filenames,
+    # which are then placed directly into TNTC_ENGINE_DIR.
+    if command -v curl >/dev/null 2>&1; then
+        curl -sSLf "${TARBALL_URL}" | tar -xz \
+            --strip-components=2 \
+            -C "${TNTC_ENGINE_DIR}" \
+            "tentacular-${VERSION_CLEAN}/engine"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O - "${TARBALL_URL}" | tar -xz \
+            --strip-components=2 \
+            -C "${TNTC_ENGINE_DIR}" \
+            "tentacular-${VERSION_CLEAN}/engine"
+    else
+        echo "Error: curl or wget is required" >&2; exit 1
+    fi
+
+    echo "Installed: ${TNTC_ENGINE_DIR}"
+}
+
 main() {
     OS=$(_detect_os)
     ARCH=$(_detect_arch)
     VERSION=${TNTC_VERSION:-$(_stable_version)}
 
+    # Install tntc binary
     URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${BINARY}_${OS}_${ARCH}"
 
     echo "Downloading tntc ${VERSION} (${OS}/${ARCH})..."
     mkdir -p "${TNTC_INSTALL_DIR}"
     _fetch "${URL}" > "${TNTC_INSTALL_DIR}/${BINARY}"
     chmod 755 "${TNTC_INSTALL_DIR}/${BINARY}"
-
     echo "Installed: ${TNTC_INSTALL_DIR}/${BINARY}"
+
+    # Install Deno engine (required for tntc test and tntc dev)
+    _install_engine "${VERSION}"
 
     case ":${PATH}:" in
         *":${TNTC_INSTALL_DIR}:"*) ;;
         *) echo "Note: add ${TNTC_INSTALL_DIR} to your PATH" ;;
     esac
 
-    echo "Run: tntc version"
+    echo ""
+    echo "Installation complete. Run: tntc version"
 }
 
 main


### PR DESCRIPTION
## Problems fixed

### 1. Clean install breaks `tntc test` and `tntc dev`

`install.sh` only downloaded the `tntc` binary. Both `tntc test` and `tntc dev` require the Deno engine directory at `~/.tentacular/engine/`, which was never installed. Any clean install left these commands broken with `cannot find engine directory`.

**Fix:** After downloading the binary, extract `engine/` from the source tarball at the same version tag into `~/.tentacular/engine/`.

### 2. CrashLoopBackOff on all cron/queue/manual workflows

`engine/main.ts` called `Deno.env.get('WEBHOOK_SECRET')` unconditionally at startup. Under gVisor's default deny-env policy, this threw `NotCapable` and crashed any workflow that did not have `github.webhook_secret` set in `.secrets.yaml` — i.e. every non-webhook workflow.

**Fix:** Move the `Deno.env.get()` call inside the `hasWebhookTrigger` guard. Cron/queue/manual workflows never touch the env var. Webhook workflows still read it as a fallback.

## Testing

- Verified `tntc test` works after clean install with updated script
- Verified cron/queue workflows start without `github.webhook_secret` stub in secrets