### PR TITLE
fix: vendor remote imports at deploy time (zero outbound network at pod startup)

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:distroless
+FROM denoland/deno:alpine
 
 WORKDIR /app
 
@@ -12,8 +12,12 @@ COPY engine/deno.json /app/deno.json
 COPY engine/deno.lock /app/deno.lock
 
 # Cache engine dependencies at build time (locked)
-RUN ["deno", "cache", "--lock=deno.lock", "engine/main.ts"]
+RUN deno cache --lock=deno.lock engine/main.ts
+
+# Copy startup script
+COPY engine/start.sh /app/start.sh
+RUN chmod +x /app/start.sh
 
 EXPOSE 8080
 
-ENTRYPOINT ["deno", "run", "--no-lock", "--unstable-net", "--allow-net", "--allow-read=/app,/var/run/secrets", "--allow-write=/tmp", "--allow-env", "engine/main.ts", "--workflow", "/app/workflow/workflow.yaml", "--port", "8080"]
+ENTRYPOINT ["/bin/sh", "/app/start.sh"]

--- a/engine/start.sh
+++ b/engine/start.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Tentacular engine startup script.
+# Extracts vendored dependencies if present, then launches the Deno engine
+# with the appropriate --import-map flag so pods need zero outbound network
+# access to resolve remote imports (jsr:, https://).
+set -e
+
+IMPORT_MAP_FLAG=""
+
+if [ -f /app/workflow/vendor.tar.gz ]; then
+  echo "Extracting vendor dependencies..."
+  mkdir -p /tmp/vendor
+  tar xzf /app/workflow/vendor.tar.gz -C /tmp/vendor/
+  if [ -f /tmp/vendor/vendor/import_map.json ]; then
+    IMPORT_MAP_FLAG="--import-map=/tmp/vendor/vendor/import_map.json"
+    echo "Using vendored imports: /tmp/vendor/vendor/import_map.json"
+  else
+    echo "Warning: vendor.tar.gz present but import_map.json not found inside — proceeding without import map"
+  fi
+fi
+
+exec deno run \
+  --no-lock \
+  --unstable-net \
+  --allow-net \
+  --allow-read=/app,/var/run/secrets,/tmp \
+  --allow-write=/tmp \
+  --allow-env \
+  ${IMPORT_MAP_FLAG} \
+  engine/main.ts \
+  --workflow /app/workflow/workflow.yaml \
+  --port 8080

--- a/pkg/builder/k8s_test.go
+++ b/pkg/builder/k8s_test.go
@@ -506,7 +506,7 @@ nodes:
 	}
 
 	wf := makeTestWorkflow("test-workflow")
-	cm, err := GenerateCodeConfigMap(wf, tmpDir, "default")
+	cm, err := GenerateCodeConfigMap(wf, tmpDir, "default", nil)
 	if err != nil {
 		t.Fatalf("GenerateCodeConfigMap failed: %v", err)
 	}
@@ -547,7 +547,7 @@ func TestConfigMapSizeValidation(t *testing.T) {
 	}
 
 	wf := makeTestWorkflow("test")
-	_, err := GenerateCodeConfigMap(wf, tmpDir, "default")
+	_, err := GenerateCodeConfigMap(wf, tmpDir, "default", nil)
 	if err == nil {
 		t.Error("expected error for oversized ConfigMap")
 	}
@@ -568,7 +568,7 @@ triggers:
 	}
 
 	wf := makeTestWorkflow("test-workflow")
-	cm, err := GenerateCodeConfigMap(wf, tmpDir, "default")
+	cm, err := GenerateCodeConfigMap(wf, tmpDir, "default", nil)
 	if err != nil {
 		t.Fatalf("GenerateCodeConfigMap failed when nodes/ missing: %v", err)
 	}
@@ -607,7 +607,7 @@ triggers:
 	}
 
 	wf := makeTestWorkflow("test")
-	cm, err := GenerateCodeConfigMap(wf, tmpDir, "default")
+	cm, err := GenerateCodeConfigMap(wf, tmpDir, "default", nil)
 	if err != nil {
 		t.Fatalf("GenerateCodeConfigMap failed: %v", err)
 	}

--- a/pkg/denovendor/vendor.go
+++ b/pkg/denovendor/vendor.go
@@ -1,0 +1,177 @@
+// Package vendor provides deno vendor integration for tntc deploy.
+// It pre-fetches all remote imports (jsr:, https://) from workflow node files
+// into a local vendor/ directory so pods have zero outbound network dependency
+// at import-resolution time.
+//
+// The vendor directory is archived as a gzipped tarball (vendor.tar.gz) and
+// stored in the workflow ConfigMap's binaryData. At pod startup, the engine's
+// start.sh script extracts it to /tmp/vendor/ and passes --import-map to Deno.
+package denovendor
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	VendorDir     = "vendor"
+	TarballName   = "vendor.tar.gz"
+	ImportMapPath = "vendor/import_map.json"
+)
+
+// VendorResult holds the outcome of a vendor run.
+type VendorResult struct {
+	// TarballPath is the absolute path to the created vendor.tar.gz.
+	TarballPath string
+	// TarballBytes is the raw content of vendor.tar.gz.
+	TarballBytes []byte
+	// Skipped is true when vendoring was skipped.
+	Skipped bool
+	// SkipReason explains why (only set when Skipped is true).
+	SkipReason string
+}
+
+// Run runs `deno vendor` in workflowDir, then archives the result as vendor.tar.gz.
+// If deno is not on PATH, returns Skipped=true (warning only, not a hard error).
+func Run(workflowDir string, w io.Writer) (*VendorResult, error) {
+	if w == nil {
+		w = io.Discard
+	}
+
+	denoPath, err := exec.LookPath("deno")
+	if err != nil {
+		return &VendorResult{
+			Skipped:    true,
+			SkipReason: "deno not found on PATH — remote imports will be resolved at pod startup (will fail under NetworkPolicy)",
+		}, nil
+	}
+
+	nodesDir := filepath.Join(workflowDir, "nodes")
+	entries, err := os.ReadDir(nodesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &VendorResult{Skipped: true, SkipReason: "nodes/ directory not found"}, nil
+		}
+		return nil, fmt.Errorf("reading nodes directory: %w", err)
+	}
+
+	var nodeFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".ts" {
+			nodeFiles = append(nodeFiles, filepath.Join("nodes", e.Name()))
+		}
+	}
+	if len(nodeFiles) == 0 {
+		return &VendorResult{Skipped: true, SkipReason: "no .ts files in nodes/"}, nil
+	}
+
+	vendorOut := filepath.Join(workflowDir, VendorDir)
+
+	fmt.Fprintf(w, "  Vendoring remote imports via deno vendor...\n")
+
+	args := []string{"vendor", "--output", vendorOut}
+	args = append(args, nodeFiles...)
+	cmd := exec.Command(denoPath, args...)
+	cmd.Dir = workflowDir
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("deno vendor failed: %w\n\nEnsure all remote imports are reachable from the deploy machine.", err)
+	}
+
+	importMap := filepath.Join(workflowDir, ImportMapPath)
+	if _, err := os.Stat(importMap); err != nil {
+		return nil, fmt.Errorf("deno vendor completed but import_map.json not found at %s", importMap)
+	}
+
+	// Archive vendor/ → vendor.tar.gz
+	tarballPath := filepath.Join(workflowDir, TarballName)
+	tarBytes, err := createTarGz(vendorOut, tarballPath)
+	if err != nil {
+		return nil, fmt.Errorf("archiving vendor directory: %w", err)
+	}
+
+	fmt.Fprintf(w, "  ✓ Vendor archive: %s (%d KB)\n", tarballPath, len(tarBytes)/1024)
+
+	return &VendorResult{
+		TarballPath:  tarballPath,
+		TarballBytes: tarBytes,
+	}, nil
+}
+
+// createTarGz archives srcDir as a gzipped tar, writing to dstPath.
+// Returns the raw bytes of the archive.
+func createTarGz(srcDir, dstPath string) ([]byte, error) {
+	f, err := os.Create(dstPath)
+	if err != nil {
+		return nil, fmt.Errorf("creating tarball: %w", err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(filepath.Dir(srcDir), path)
+		if err != nil {
+			return err
+		}
+		// Use forward slashes in tar headers (cross-platform)
+		relPath = filepath.ToSlash(relPath)
+
+		hdr := &tar.Header{
+			Name:    relPath,
+			Mode:    int64(info.Mode()),
+			ModTime: info.ModTime(),
+		}
+		if info.IsDir() {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Name += "/"
+		} else {
+			hdr.Typeflag = tar.TypeReg
+			hdr.Size = info.Size()
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			rf, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer rf.Close()
+			if _, err := io.Copy(tw, rf); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Flush and close before reading
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+
+	return os.ReadFile(dstPath)
+}


### PR DESCRIPTION
## Problem

Node TypeScript files are uploaded as raw source via ConfigMap and compiled by Deno at pod startup. Any `jsr:` or `https://` imports are fetched from the network at that moment — inside gVisor, behind multiple layers of NetworkPolicy egress enforcement. This causes pods to crash immediately on import resolution.

## Solution

`tntc deploy` now runs `deno vendor` locally before packaging the ConfigMap:

1. **`pkg/denovendor`** — runs `deno vendor nodes/*.ts`, archives the result as `vendor.tar.gz`
2. **`pkg/builder`** — stores `vendor.tar.gz` in ConfigMap `binaryData` (avoids ConfigMap key restrictions on `@` and `/` characters in vendor paths); adds `HasVendor` to `DeployOptions` to include the item in the volume mount
3. **`pkg/cli/deploy`** — calls `denovendor.Run` before `GenerateCodeConfigMap`; skips with a warning if `deno` not on PATH (backward compatible)
4. **`engine/Dockerfile`** — switches base from `distroless` to `alpine` to support the shell entrypoint
5. **`engine/start.sh`** — extracts `vendor.tar.gz` to `/tmp/vendor/` at pod startup; passes `--import-map=/tmp/vendor/vendor/import_map.json` to Deno when present; no-ops when absent (backward compatible with deploys that have no vendor tarball)

## Backward compatibility

- Deploys without `deno` on PATH: vendor step is skipped with a warning; behavior unchanged
- Existing deployed workflows: no redeployment needed; `start.sh` no-ops when no `vendor.tar.gz` present
- Engine image rebuild required (distroless → alpine + start.sh)

## Notes

- Package is named `denovendor` (not `vendor`) to avoid Go gitignore convention conflict
- Size check: vendor.tar.gz + workflow code must stay under 900KB ConfigMap limit; clear error if exceeded
- `--allow-read` extended to include `/tmp` so Deno can access extracted vendor files