### PR TITLE
fix: engine import map — merge engine deps with workflow proxy entries

### DIFF
--- a/pkg/builder/k8s.go
+++ b/pkg/builder/k8s.go
@@ -159,9 +159,12 @@ func GenerateK8sManifests(wf *spec.Workflow, imageTag, namespace string, opts De
 	importMapVolumeMount := ""
 	importMapVolume := ""
 	if spec.HasModuleProxyDeps(wf) {
+		// Mount the merged deno.json (engine + workflow deps) at /app/deno.json.
+		// This overrides the image-baked deno.json so Deno auto-discovers it
+		// without needing --import-map (which would break engine import aliases).
 		importMapVolumeMount = `            - name: import-map
-              mountPath: /app/workflow/import_map.json
-              subPath: import_map.json
+              mountPath: /app/deno.json
+              subPath: deno.json
               readOnly: true
 `
 		importMapVolume = fmt.Sprintf(`        - name: import-map

--- a/pkg/spec/derive.go
+++ b/pkg/spec/derive.go
@@ -330,11 +330,9 @@ func DeriveDenoFlags(c *Contract) []string {
 		"--allow-env=DENO_DIR,HOME",
 	}
 
-	// Add import map when module proxy deps (jsr/npm) are present.
-	// The import map ConfigMap is mounted at /app/workflow/import_map.json by the Deployment.
-	if hasModuleProxyDeps {
-		flags = append(flags, "--import-map=/app/workflow/import_map.json")
-	}
+	// Note: when jsr/npm deps are present, the Deployment mounts a merged deno.json
+	// (engine imports + workflow proxy rewrites) at /app/deno.json. Deno auto-discovers
+	// this config — no --import-map flag needed (which would override and break engine deps).
 
 	flags = append(flags,
 		"engine/main.ts",

--- a/pkg/spec/module_proxy_test.go
+++ b/pkg/spec/module_proxy_test.go
@@ -167,9 +167,10 @@ func TestDeriveDenoFlagsModuleProxy(t *testing.T) {
 
 	flagStr := strings.Join(flags, " ")
 
-	// Should include import map flag
-	if !strings.Contains(flagStr, "--import-map=/app/workflow/import_map.json") {
-		t.Errorf("expected --import-map flag, got: %s", flagStr)
+	// Should NOT include --import-map flag — the merged deno.json is auto-discovered
+	// at /app/deno.json via ConfigMap mount, no flag needed.
+	if strings.Contains(flagStr, "--import-map") {
+		t.Errorf("expected no --import-map flag (auto-discovered deno.json), got: %s", flagStr)
 	}
 
 	// Should include proxy host in --allow-net


### PR DESCRIPTION
## Problem

`--import-map` in Deno 2 completely overrides `deno.json`'s import map. The previous approach would have silently broken all engine imports (`std/path`, `tentacular`, `@nats-io/transport-deno`, etc.) at runtime when jsr/npm deps were present.

## Fix

Generate a merged `deno.json` ConfigMap containing both engine import entries and workflow jsr/npm → esm.sh rewrites. Mount at `/app/deno.json` — Deno auto-discovers it, no `--import-map` flag needed.

## Note

This fix was originally pushed directly to main (fa3d40a). This PR documents and tracks the change retroactively. Main already contains this commit.