### PR TITLE
fix: esm-sh v136, /.esmd mount, versioned import map keys, cluster proxy check

### DIFF
--- a/pkg/cli/cluster.go
+++ b/pkg/cli/cluster.go
@@ -32,7 +32,7 @@ func NewClusterCmd() *cobra.Command {
 	install.Flags().String("proxy-namespace", "", "Namespace for module proxy (default: tentacular-system)")
 	install.Flags().String("proxy-storage", "", "Module proxy cache storage: emptydir (default) or pvc")
 	install.Flags().String("proxy-pvc-size", "", "PVC size when storage=pvc (default: 5Gi)")
-	install.Flags().String("proxy-image", "", "Module proxy image (default: ghcr.io/esm-dev/esm.sh:v135)")
+	install.Flags().String("proxy-image", "", "Module proxy image (default: ghcr.io/esm-dev/esm.sh:v136)")
 
 	cluster.AddCommand(check)
 	cluster.AddCommand(install)
@@ -57,6 +57,14 @@ func runClusterCheck(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("preflight check failed: %w", err)
 	}
+
+	// Append module proxy check (informational: not installed = warning, not failure)
+	cfg := LoadConfig()
+	proxyNS := cfg.ModuleProxy.Namespace
+	if proxyNS == "" {
+		proxyNS = "tentacular-system"
+	}
+	results = append(results, client.CheckModuleProxy(proxyNS))
 
 	// JSON output
 	if output == "json" {

--- a/pkg/k8s/importmap_test.go
+++ b/pkg/k8s/importmap_test.go
@@ -55,8 +55,13 @@ func TestGenerateImportMapWithNamespace(t *testing.T) {
 		if !strings.Contains(got.Content, "namespace: prod") {
 			t.Error("expected namespace prod in manifest")
 		}
-		if !strings.Contains(got.Content, "jsr:@db/postgres") {
-			t.Error("expected jsr specifier in import map")
+		// Both the versioned key (for code that imports with @version) and the
+		// unversioned key (fallback for bare imports) must be present.
+		if !strings.Contains(got.Content, "jsr:@db/postgres@^0.4") {
+			t.Error("expected versioned jsr specifier key (e.g. jsr:@db/postgres@^0.4) in import map")
+		}
+		if !strings.Contains(got.Content, "\"jsr:@db/postgres\"") {
+			t.Error("expected unversioned jsr specifier key (fallback) in import map")
 		}
 		if !strings.Contains(got.Content, "/jsr/@db/postgres@^0.4") {
 			t.Error("expected proxy path with version in import map")
@@ -77,8 +82,13 @@ func TestGenerateImportMapWithNamespace(t *testing.T) {
 		if got == nil {
 			t.Fatal("expected non-nil manifest")
 		}
-		if !strings.Contains(got.Content, "npm:zod") {
-			t.Error("expected npm specifier in import map")
+		// Versioned key for code using "npm:zod@^3"
+		if !strings.Contains(got.Content, "npm:zod@^3") {
+			t.Error("expected versioned npm specifier key (npm:zod@^3) in import map")
+		}
+		// Unversioned fallback key for code using "npm:zod"
+		if !strings.Contains(got.Content, "\"npm:zod\"") {
+			t.Error("expected unversioned npm specifier key (fallback) in import map")
 		}
 		if !strings.Contains(got.Content, "/zod@^3") {
 			t.Error("expected proxy path with version in import map")


### PR DESCRIPTION
## Summary

Three bugs found in v0.1.5 after the esm-module-proxy feature landed.

### Bug 1 — esm-sh container crashes on startup
**Root cause:** `ghcr.io/esm-dev/esm.sh:v135` tries to install `esm-node-services` via pnpm at startup; that package was subsequently unpublished from npm.
**Fix:** Bump to `v136`, which ships a built-in Go npm package manager and has no pnpm/esm-node-services dependency.

**Also:** The cache volume was mounted at `/esm.sh/cache` but esm.sh writes to `/.esmd`. Fixed mount path. With the emptyDir at `/.esmd` (world-writable on creation), `runAsUser: 65534` can write cache data without relaxing the security context.

### Bug 2 — `tntc cluster check` doesn't report proxy status
**Root cause:** `runClusterCheck` only ran the namespace/RBAC/secret preflight — no visibility into whether esm-sh is installed or healthy.
**Fix:** Added `CheckModuleProxy(namespace)` to `pkg/k8s/preflight.go` and wired it into `runClusterCheck`:
- Not installed → `✓` with a warning hint (informational, non-blocking)
- Installed but not ready → `✗` with kubectl log hint (blocking)
- Installed and ready → `✓`

### Bug 3 — Import map specifier keys missing version
**Root cause:** Deno import maps use exact-key lookup. Code that imports `jsr:@db/postgres@0.19.5` never matched the map key `jsr:@db/postgres` we were emitting — Deno fell through to jsr.io, which is blocked by NetworkPolicy.
**Fix:** When `dep.Version` is set, emit two entries in the merged `deno.json`:
- `jsr:@scope/pkg@version` — exact match for versioned imports (the common case)
- `jsr:@scope/pkg` — unversioned fallback

Both point to the versioned proxy URL. Same dual-key logic for `npm:` specifiers.

## Tests
All existing tests pass; updated `TestGenerateImportMapWithNamespace` to assert both versioned and unversioned keys are present.