### PR TITLE
fix: /app/engine/deno.json mount, --allow-import, DENO_DIR env, proxy prewarm initContainer

### DIFF
--- a/pkg/spec/derive.go
+++ b/pkg/spec/derive.go
@@ -330,9 +330,16 @@ func DeriveDenoFlags(c *Contract) []string {
 		"--allow-env=DENO_DIR,HOME",
 	}
 
+	// Deno 2 requires explicit --allow-import permission for any host from which
+	// modules are imported. The in-cluster module proxy is not on Deno's built-in
+	// allowlist, so workflow pods that use jsr:/npm: deps must explicitly allow it.
+	if hasModuleProxyDeps {
+		flags = append(flags, "--allow-import="+moduleProxyHost)
+	}
+
 	// Note: when jsr/npm deps are present, the Deployment mounts a merged deno.json
-	// (engine imports + workflow proxy rewrites) at /app/deno.json. Deno auto-discovers
-	// this config — no --import-map flag needed (which would override and break engine deps).
+	// (engine imports + workflow proxy rewrites) at /app/engine/deno.json. Deno
+	// auto-discovers this config — no --import-map flag needed.
 
 	flags = append(flags,
 		"engine/main.ts",


### PR DESCRIPTION
## v0.1.8 — four bugs from e2e testing

### Bug 1 — Wrong deno.json mount path
`/app/deno.json` → `/app/engine/deno.json`. Deno's config discovery walks UP from the entrypoint (`engine/main.ts`), so it finds `/app/engine/deno.json` first. The import map was never being applied.

### Bug 2 — Missing `--allow-import`
Deno 2 requires explicit `--allow-import=<host>` for any host not on its built-in allowlist. The in-cluster proxy (`esm-sh.tentacular-system.svc.cluster.local:8080`) was triggering "Requires import access" errors. Added to `DeriveDenoFlags` when jsr/npm deps present.

### Bug 3 — Missing `DENO_DIR` env var
`--allow-env=DENO_DIR` allows Deno to READ the var, but it still needs to be SET. With gVisor, `/deno-dir` is read-only. Added `DENO_DIR=/tmp/deno-cache` to the engine container env (already in `--allow-write=/tmp`).

### Bug 4 — Proxy cold-start timeout
First build of a module (e.g. `jsr:@db/postgres`) exceeds esm.sh's 60s context deadline at pod startup. Added a `proxy-prewarm` **initContainer** (`curlimages/curl`, `--retry 3 --max-time 120`) that pre-fetches all jsr/npm dep URLs before the engine container starts. Build latency is absorbed by init, not pod startup.

`ModuleProxyURL` added to `builder.DeployOptions`; proxy URL now resolved before `GenerateK8sManifests`.