### PR TITLE
fix: initContainer YAML quoting, --allow-read cleanup, tntc run readiness wait

### DIFF
--- a/pkg/builder/e2e_security_test.go
+++ b/pkg/builder/e2e_security_test.go
@@ -161,7 +161,7 @@ func TestE2E_DenoFlagsCommandStructure(t *testing.T) {
 			"- --no-lock",
 			"- --unstable-net",
 			"- --allow-net=0.0.0.0:8080,api.github.com:443,hooks.slack.com:443",
-			"- --allow-read=/app,/var/run/secrets",
+			"- --allow-read=/app",
 			"- --allow-write=/tmp",
 			"- --allow-env=DENO_DIR,HOME",
 			"- engine/main.ts",

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -17,7 +17,8 @@ func NewRunCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  runRun,
 	}
-	cmd.Flags().Duration("timeout", 30*time.Second, "Maximum time to wait for result")
+	cmd.Flags().Duration("timeout", 120*time.Second, "Maximum time to wait for readiness + result")
+	cmd.Flags().Bool("no-wait", false, "Skip readiness check and run immediately")
 	return cmd
 }
 
@@ -25,6 +26,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	namespace, _ := cmd.Flags().GetString("namespace")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
+	noWait, _ := cmd.Flags().GetBool("no-wait")
 
 	client, err := k8s.NewClient()
 	if err != nil {
@@ -33,6 +35,17 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
+	// Wait for the deployment to be ready before triggering.
+	// Without this, the runner curl pod fires immediately; if the workflow pod
+	// hasn't passed its readiness probe yet the Service has no endpoints and
+	// the run fails with a connection-refused error (the port-forward race).
+	if !noWait {
+		fmt.Fprintf(os.Stderr, "Waiting for %s to be ready...\n", name)
+		if err := client.WaitForReady(ctx, namespace, name); err != nil {
+			return fmt.Errorf("workflow not ready: %w (use --no-wait to skip readiness check)", err)
+		}
+	}
 
 	fmt.Fprintf(os.Stderr, "Running workflow %s in %s...\n", name, namespace)
 

--- a/pkg/spec/derive.go
+++ b/pkg/spec/derive.go
@@ -325,7 +325,7 @@ func DeriveDenoFlags(c *Contract) []string {
 		"--no-lock",
 		"--unstable-net",
 		allowNetFlag,
-		"--allow-read=/app,/var/run/secrets",
+		"--allow-read=/app",
 		"--allow-write=/tmp",
 		"--allow-env=DENO_DIR,HOME",
 	}


### PR DESCRIPTION
## v0.1.9 — three bugs from v0.1.8 testing

### Bug 1 — initContainer command marshaled as object
The shell script was inserted unquoted into YAML (`- %s`). Two problems:
1. `> /dev/null` and `||` — YAML operators when bare
2. `echo 'prewarm non-fatal: http://...'` — the `: ` in the echo text caused YAML to split the scalar into `key: value`, making the third command item a **map** instead of a string. K8s rejected the Deployment entirely.

**Fix:** Use `- %q` (Go double-quotes the string). In YAML double-quoted scalars, `>`, `|`, `||`, and `: ` are all literals. Also replaced the `|| echo ...` fallback with `|| true` — cleaner and avoids future colon-in-message issues.

### Bug 2 — `--allow-read` includes unused `/var/run/secrets`
`--allow-read=/app,/var/run/secrets` was misleading: secrets are mounted at `/app/secrets` (already under `/app`) and `automountServiceAccountToken: false` means `/var/run/secrets` is never populated.

**Fix:** Simplified to `--allow-read=/app` — covers all engine read paths without implying secrets live at `/var/run/secrets`.

### Bug 3 — `tntc run` port-forward race
`tntc run` fired the curl runner pod immediately. If the workflow pod hadn't passed its readiness probe yet, the Service had no endpoints — curl got connection-refused, retried for ~10s, then failed silently (context timeout).

**Fix:** `runRun` now calls `WaitForReady` before `RunWorkflow`. Pod ready = Service endpoint live = run succeeds on first attempt. Added `--no-wait` flag to skip for scripted use. Bumped default timeout 30s → 120s.