### PR TITLE
fix: --allow-import=deno.land,<proxy> — deno.land was silently dropped

### DIFF
--- a/pkg/spec/module_proxy_test.go
+++ b/pkg/spec/module_proxy_test.go
@@ -178,9 +178,13 @@ func TestDeriveDenoFlagsModuleProxy(t *testing.T) {
 		t.Errorf("expected module proxy host %s in --allow-net, got: %s", moduleProxyHost, flagStr)
 	}
 
-	// Should include --allow-import for the proxy host (Deno 2 requires explicit import permission)
-	if !strings.Contains(flagStr, "--allow-import="+moduleProxyHost) {
-		t.Errorf("expected --allow-import=%s, got: %s", moduleProxyHost, flagStr)
+	// --allow-import must include BOTH deno.land (engine std lib, re-fetched
+	// because DENO_DIR=/tmp/deno-cache is empty at pod start) AND the proxy host.
+	// Setting --allow-import replaces Deno's built-in allowlist, so both must
+	// be listed explicitly or deno.land imports fail at engine startup.
+	wantImport := "--allow-import=deno.land," + moduleProxyHost
+	if !strings.Contains(flagStr, wantImport) {
+		t.Errorf("expected %s in flags, got: %s", wantImport, flagStr)
 	}
 
 	// Should still include the https dep host


### PR DESCRIPTION
## v0.1.10 — deno.land missing from --allow-import

### Root cause
`--allow-import=<host>` in Deno 2 **replaces** the built-in allowlist (deno.land, esm.sh, jsr.io, …) rather than extending it. v0.1.9 set `--allow-import=<proxyHost>` for jsr/npm workflows, which silently removed `deno.land` from the allowlist.

### Why deno.land is always needed when the flag is set
1. Engine image builds as uid 1000 (deno user); pod runs as uid 65534 (nobody) — image-baked Deno cache at `~/.cache/deno` is not readable by the pod.
2. `DENO_DIR=/tmp/deno-cache` (added in v0.1.8) is empty at pod start, so Deno must re-fetch all engine std lib imports from `deno.land` over the network.
3. Without `deno.land` in `--allow-import`, those fetches fail at engine startup before any workflow code runs.

### Fix
`--allow-import=deno.land,<proxyHost>` when jsr/npm proxy deps present.
No change for non-proxy workflows — Deno's default allowlist already includes `deno.land`.