### PR TITLE
fix: --allow-import deno.land:443 and thread proxy namespace

### DIFF
--- a/pkg/builder/k8s.go
+++ b/pkg/builder/k8s.go
@@ -177,7 +177,14 @@ func GenerateK8sManifests(wf *spec.Workflow, imageTag, namespace string, opts De
 
 	// Build command/args block for Deno permission flags (10-space indent for container-level)
 	commandArgsBlock := ""
-	denoFlags := spec.DeriveDenoFlags(wf.Contract)
+	// Extract host:port from ModuleProxyURL for DeriveDenoFlags scoping.
+	// If empty, DeriveDenoFlags falls back to the default constant.
+	proxyHost := ""
+	if opts.ModuleProxyURL != "" {
+		proxyHost = strings.TrimPrefix(opts.ModuleProxyURL, "http://")
+		proxyHost = strings.TrimRight(proxyHost, "/")
+	}
+	denoFlags := spec.DeriveDenoFlags(wf.Contract, proxyHost)
 	if denoFlags != nil && len(denoFlags) > 0 {
 		var lines []string
 		lines = append(lines, "          command:")

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -396,7 +396,8 @@ func deployWorkflow(workflowDir string, opts InternalDeployOptions) (*DeployResu
 	manifests = append([]builder.Manifest{configMap}, manifests...)
 
 	// Add NetworkPolicy if contract present
-	if netpol := k8s.GenerateNetworkPolicy(wf, namespace); netpol != nil {
+	proxyNamespace := cfg.ModuleProxy.Namespace
+	if netpol := k8s.GenerateNetworkPolicy(wf, namespace, proxyNamespace); netpol != nil {
 		manifests = append(manifests, *netpol)
 	}
 

--- a/pkg/k8s/e2e_security_test.go
+++ b/pkg/k8s/e2e_security_test.go
@@ -77,7 +77,7 @@ contract:
 	}
 
 	// Step 3: Verify DeriveDenoFlags returns broad --allow-net (dynamic-target present)
-	denoFlags := spec.DeriveDenoFlags(wf.Contract)
+	denoFlags := spec.DeriveDenoFlags(wf.Contract, "")
 	if denoFlags == nil {
 		t.Fatal("expected non-nil DeriveDenoFlags result for contract with dependencies")
 	}
@@ -166,7 +166,7 @@ contract:
 	}
 
 	// Step 6: Generate NetworkPolicy
-	manifest := GenerateNetworkPolicy(wf, "tentacular-dev")
+	manifest := GenerateNetworkPolicy(wf, "tentacular-dev", "")
 	if manifest == nil {
 		t.Fatal("expected non-nil NetworkPolicy manifest")
 	}
@@ -251,7 +251,7 @@ contract:
 	}
 
 	// DeriveDenoFlags should return scoped --allow-net= with specific hosts
-	denoFlags := spec.DeriveDenoFlags(wf.Contract)
+	denoFlags := spec.DeriveDenoFlags(wf.Contract, "")
 	if denoFlags == nil {
 		t.Fatal("expected non-nil DeriveDenoFlags result")
 	}
@@ -270,7 +270,7 @@ contract:
 	}
 
 	// NetworkPolicy should have host-specific egress only (no CIDR wildcard)
-	manifest := GenerateNetworkPolicy(wf, "tentacular-dev")
+	manifest := GenerateNetworkPolicy(wf, "tentacular-dev", "")
 	if manifest == nil {
 		t.Fatal("expected non-nil NetworkPolicy manifest")
 	}
@@ -326,13 +326,13 @@ edges: []
 	}
 
 	// DeriveDenoFlags should return nil
-	denoFlags := spec.DeriveDenoFlags(wf.Contract)
+	denoFlags := spec.DeriveDenoFlags(wf.Contract, "")
 	if denoFlags != nil {
 		t.Errorf("expected nil DeriveDenoFlags for nil contract, got %v", denoFlags)
 	}
 
 	// NetworkPolicy should not be generated
-	manifest := GenerateNetworkPolicy(wf, "tentacular-dev")
+	manifest := GenerateNetworkPolicy(wf, "tentacular-dev", "")
 	if manifest != nil {
 		t.Error("expected nil NetworkPolicy for workflow without contract")
 	}
@@ -390,7 +390,7 @@ contract:
 	}
 
 	// Generate NetworkPolicy and verify ingress section
-	manifest := GenerateNetworkPolicy(wf, "tentacular-dev")
+	manifest := GenerateNetworkPolicy(wf, "tentacular-dev", "")
 	if manifest == nil {
 		t.Fatal("expected non-nil NetworkPolicy manifest")
 	}

--- a/pkg/k8s/netpol_test.go
+++ b/pkg/k8s/netpol_test.go
@@ -17,7 +17,7 @@ func TestGenerateNetworkPolicyNilContract(t *testing.T) {
 		// No contract
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest != nil {
 		t.Error("expected nil manifest for workflow without contract")
@@ -35,7 +35,7 @@ func TestGenerateNetworkPolicyEmptyContract(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest for empty contract")
@@ -72,7 +72,7 @@ func TestGenerateNetworkPolicySingleHTTPSDependency(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -129,7 +129,7 @@ func TestGenerateNetworkPolicyPostgreSQLDependency(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "pd-test")
+	manifest := GenerateNetworkPolicy(wf, "pd-test", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -176,7 +176,7 @@ func TestGenerateNetworkPolicyMultipleDependencies(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -211,7 +211,7 @@ func TestGenerateNetworkPolicyWebhookTriggerIngress(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -256,7 +256,7 @@ func TestGenerateNetworkPolicyNonWebhookTriggerNoIngress(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -279,7 +279,7 @@ func TestGenerateNetworkPolicyLabels(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -310,7 +310,7 @@ func TestGenerateNetworkPolicyPolicyTypes(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -363,7 +363,7 @@ func TestGenerateNetworkPolicyDNSAlwaysIncluded(t *testing.T) {
 				},
 			}
 
-			manifest := GenerateNetworkPolicy(wf, "default")
+			manifest := GenerateNetworkPolicy(wf, "default", "")
 
 			if manifest == nil {
 				t.Fatal("expected non-nil manifest")
@@ -393,7 +393,7 @@ func TestGenerateNetworkPolicyValidYAML(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -429,7 +429,7 @@ func TestGenerateNetworkPolicyNamespacing(t *testing.T) {
 				},
 			}
 
-			manifest := GenerateNetworkPolicy(wf, ns)
+			manifest := GenerateNetworkPolicy(wf, ns, "")
 
 			if manifest == nil {
 				t.Fatal("expected non-nil manifest")
@@ -462,7 +462,7 @@ func TestGenerateNetworkPolicyAdditionalEgressOverride(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -511,7 +511,7 @@ func TestGenerateNetworkPolicyDefaultPortApplication(t *testing.T) {
 		},
 	}
 
-	manifest := GenerateNetworkPolicy(wf, "default")
+	manifest := GenerateNetworkPolicy(wf, "default", "")
 
 	if manifest == nil {
 		t.Fatal("expected non-nil manifest")
@@ -650,7 +650,7 @@ contract:
 	}
 
 	// Step 6: Generate NetworkPolicy
-	manifest := GenerateNetworkPolicy(wf, "tentacular-test")
+	manifest := GenerateNetworkPolicy(wf, "tentacular-test", "")
 	if manifest == nil {
 		t.Fatal("expected non-nil NetworkPolicy manifest")
 	}

--- a/pkg/spec/derive_test.go
+++ b/pkg/spec/derive_test.go
@@ -271,7 +271,7 @@ func TestGetSecretKeyName(t *testing.T) {
 }
 
 func TestDeriveDenoFlagsNilContract(t *testing.T) {
-	flags := DeriveDenoFlags(nil)
+	flags := DeriveDenoFlags(nil, "")
 	if flags != nil {
 		t.Errorf("expected nil flags for nil contract, got %v", flags)
 	}
@@ -281,7 +281,7 @@ func TestDeriveDenoFlagsEmptyDependencies(t *testing.T) {
 	contract := &Contract{
 		Dependencies: map[string]Dependency{},
 	}
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags != nil {
 		t.Errorf("expected nil flags for empty dependencies, got %v", flags)
 	}
@@ -298,7 +298,7 @@ func TestDeriveDenoFlagsFixedHostScoped(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags for fixed-host dependency")
 	}
@@ -342,7 +342,7 @@ func TestDeriveDenoFlagsDynamicTargetBroad(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags for dynamic-target dependency")
 	}
@@ -377,7 +377,7 @@ func TestDeriveDenoFlagsMixedDependenciesBroad(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags for mixed dependencies")
 	}
@@ -411,7 +411,7 @@ func TestDeriveDenoFlagsDefaultPortResolution(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags for fixed-host dependencies")
 	}
@@ -450,7 +450,7 @@ func TestDeriveDenoFlagsMultipleFixedSorted(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags for multiple fixed-host dependencies")
 	}
@@ -480,7 +480,7 @@ func TestDeriveDenoFlagsAlwaysIncludesLocalhost(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags")
 	}
@@ -509,7 +509,7 @@ func TestDeriveDenoFlagsScopedAllowEnv(t *testing.T) {
 		},
 	}
 
-	flags := DeriveDenoFlags(contract)
+	flags := DeriveDenoFlags(contract, "")
 	if flags == nil {
 		t.Fatal("expected non-nil flags")
 	}


### PR DESCRIPTION
## Summary
- Fix `--allow-import=deno.land` missing `:443` port (Deno 2 rejects it at runtime)
- Thread proxy host through `DeriveDenoFlags` and proxy namespace through `GenerateNetworkPolicy` instead of hardcoding `tentacular-system`
- Remove `moduleProxyHost` constant and all default fallbacks -- callers must provide explicit values

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/spec/... ./pkg/builder/... ./pkg/k8s/... ./pkg/cli/...` -- 414 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)