### PR TITLE
fix: bulk fixes for MCP server refactoring

### DIFF
--- a/openspec/changes/bulk-fixes-for-mcp-refactoring/.openspec.yaml
+++ b/openspec/changes/bulk-fixes-for-mcp-refactoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-27

--- a/openspec/changes/bulk-fixes-for-mcp-refactoring/design.md
+++ b/openspec/changes/bulk-fixes-for-mcp-refactoring/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The MCP server refactoring moved deployment orchestration from the CLI to the MCP server. During end-to-end testing, four issues were found that prevent correct operation in PSA-restricted (baseline/restricted) namespaces. All four are in `pkg/builder/k8s.go` manifest generation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix import map path so Deno engine resolves modules correctly
+- Make proxy-prewarm and CronJob trigger pods PSA-compliant
+- Generate egress NetworkPolicy for trigger pods
+- Fix secrets volume mount condition to work with contract dependencies
+
+**Non-Goals:**
+- Refactoring the manifest generation architecture
+- Adding new deployment capabilities
+- Changing the MCP server itself (separate repo)
+
+## Decisions
+
+### Import map path fix
+The ConfigMap-based code delivery mounts code at `/app/` and the engine entrypoint is `/app/mod.ts`. The import map was incorrectly referencing `./engine/mod.ts` (the old source tree layout). Change to `./mod.ts`.
+
+### PSA security context pattern
+Use the same security context pattern as the main workflow container: `runAsNonRoot: true`, `runAsUser: 65534` (nobody), `allowPrivilegeEscalation: false`, `capabilities: {drop: ["ALL"]}`. Apply to both proxy-prewarm initContainer and CronJob trigger pod spec.
+
+### Trigger egress NetworkPolicy
+CronJob trigger pods need to reach the workflow Service on port 8080. Generate a NetworkPolicy with podSelector matching trigger pod labels and egress to the workflow Service. This follows the existing default-deny + allow pattern.
+
+### Secrets check fix
+The current code checks `if len(spec.Secrets) > 0` to decide whether to mount the secrets volume. With contract dependencies, secrets are derived from `spec.Contract.Dependencies` instead. Change the check to look at contract dependencies that have secrets.
+
+## Design Decisions
+
+### Dual trigger NetworkPolicy implementation (import cycle constraint)
+
+There are two implementations of trigger NetworkPolicy generation:
+
+1. `GenerateTriggerNetworkPolicy` in `pkg/k8s/netpol.go` — public, used by external callers such as `deploy.go`.
+2. A private equivalent inside `pkg/builder/k8s.go` — used internally by `GenerateK8sManifests()`.
+
+Both produce equivalent output. The duplication exists because `pkg/builder` imports `pkg/spec` and `pkg/k8s` imports `pkg/builder` (for the `builder.Manifest` type). If `pkg/builder` were to import `pkg/k8s`, it would create a circular import. The correct long-term fix is to extract the `Manifest` type into a separate `pkg/types` package so both `pkg/builder` and `pkg/k8s` can import it without a cycle, but that refactoring is out of scope for this change.
+
+## Risks / Trade-offs
+
+- **Trigger NetworkPolicy adds another manifest**: Small increase in generated manifest count. Acceptable given the security benefit of explicit egress rules.
+- **PSA security context on curl image**: `curlimages/curl` runs as non-root by default, so adding explicit securityContext is redundant but required for PSA validation.

--- a/openspec/changes/bulk-fixes-for-mcp-refactoring/proposal.md
+++ b/openspec/changes/bulk-fixes-for-mcp-refactoring/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+After the MCP server refactoring, several issues were discovered during end-to-end testing that prevent workflows from deploying and running correctly in PSA-restricted namespaces. These are small, targeted fixes that individually are straightforward but collectively block production use of the MCP-based deployment flow.
+
+## What Changes
+
+- Fix import map path in generated Deno config (`./engine/mod.ts` to `./mod.ts`) so the engine resolves modules correctly in the ConfigMap-based code delivery model
+- Add PSA-compliant security context to proxy-prewarm init container and CronJob trigger pods (runAsNonRoot, runAsUser 65534, drop ALL capabilities)
+- Generate egress NetworkPolicy for trigger pods so CronJob curl containers can reach the workflow Service
+- Fix secrets volume mount check to use contract dependency names instead of raw secret names
+
+## Capabilities
+
+### New Capabilities
+- `trigger-egress-netpol`: Generate a NetworkPolicy allowing trigger pod egress to the workflow Service on port 8080
+
+### Modified Capabilities
+- `k8s-manifest-gen`: Fix import map path, add PSA security context to proxy-prewarm and CronJob trigger, fix secrets check logic
+
+## Impact
+
+- `pkg/builder/k8s.go`: Fix import map `./engine/mod.ts` to `./mod.ts`; add securityContext to proxy-prewarm initContainer; add securityContext to CronJob trigger pod; generate trigger egress NetworkPolicy; fix secrets volume mount condition to check contract dependencies
+- `pkg/builder/k8s_test.go`: Add/update tests for all four fixes

--- a/openspec/changes/bulk-fixes-for-mcp-refactoring/tasks.md
+++ b/openspec/changes/bulk-fixes-for-mcp-refactoring/tasks.md
@@ -1,0 +1,26 @@
+## 1. Import Map Path Fix
+
+- [ ] 1.1 Fix `./engine/mod.ts` to `./mod.ts` in import map generation in `pkg/builder/k8s.go`
+- [ ] 1.2 Add test verifying correct import map path in `pkg/builder/k8s_test.go`
+
+## 2. PSA Security Context
+
+- [ ] 2.1 Add securityContext to proxy-prewarm initContainer in `pkg/builder/k8s.go`
+- [ ] 2.2 Add securityContext to CronJob trigger pod spec in `pkg/builder/k8s.go`
+- [ ] 2.3 Add tests verifying securityContext in proxy-prewarm and CronJob trigger
+
+## 3. Trigger Egress NetworkPolicy
+
+- [ ] 3.1 Add `generateTriggerEgressNetPol()` function in `pkg/builder/k8s.go`
+- [ ] 3.2 Call from `GenerateK8sManifests()` when cron triggers exist
+- [ ] 3.3 Add tests for trigger egress NetworkPolicy generation
+
+## 4. Secrets Check Fix
+
+- [ ] 4.1 Change secrets volume mount condition from `len(spec.Secrets) > 0` to check contract dependencies
+- [ ] 4.2 Add test verifying secrets mount with contract dependencies
+
+## 5. Verification
+
+- [ ] 5.1 Run `go test ./pkg/builder/...` -- all pass
+- [ ] 5.2 Run `go test ./pkg/...` -- all pass

--- a/pkg/builder/e2e_security_test.go
+++ b/pkg/builder/e2e_security_test.go
@@ -118,6 +118,190 @@ func TestE2E_DeploymentSecurityHardeningComplete(t *testing.T) {
 	}
 }
 
+// TestE2E_ProxyPrewarmInitContainerSecurityContext verifies that the proxy-prewarm init
+// container has the required PSA-compliant security context fields.
+func TestE2E_ProxyPrewarmInitContainerSecurityContext(t *testing.T) {
+	wf := &spec.Workflow{
+		Name:    "prewarm-sec",
+		Version: "1.0",
+		Triggers: []spec.Trigger{
+			{Type: "manual"},
+		},
+		Nodes: map[string]spec.NodeSpec{
+			"fetch": {Path: "./nodes/fetch.ts"},
+		},
+		Contract: &spec.Contract{
+			Dependencies: map[string]spec.Dependency{
+				"pg": {Protocol: "jsr", Host: "@db/postgres", Version: "^0.4"},
+			},
+		},
+	}
+
+	manifests := GenerateK8sManifests(wf, "test:latest", "default", DeployOptions{
+		ModuleProxyURL: "http://esm-sh.tentacular-support.svc.cluster.local:8080",
+	})
+
+	dep := manifests[0].Content
+
+	// Init container must be present
+	if !strings.Contains(dep, "initContainers:") {
+		t.Fatal("expected initContainers block in Deployment with jsr dep and proxy URL")
+	}
+	if !strings.Contains(dep, "proxy-prewarm") {
+		t.Error("expected proxy-prewarm init container name")
+	}
+
+	// PSA-required security context on init container
+	if !strings.Contains(dep, "readOnlyRootFilesystem: true") {
+		t.Error("expected readOnlyRootFilesystem: true in proxy-prewarm init container")
+	}
+	if !strings.Contains(dep, "allowPrivilegeEscalation: false") {
+		t.Error("expected allowPrivilegeEscalation: false in proxy-prewarm init container")
+	}
+	if !strings.Contains(dep, "- ALL") {
+		t.Error("expected capabilities drop ALL in proxy-prewarm init container")
+	}
+}
+
+// TestE2E_CronJobTriggerSecurityContext verifies that generated CronJob trigger pods
+// have the required PSA-compliant security context at both pod and container level.
+func TestE2E_CronJobTriggerSecurityContext(t *testing.T) {
+	wf := &spec.Workflow{
+		Name:    "cron-sec",
+		Version: "1.0",
+		Triggers: []spec.Trigger{
+			{Type: "cron", Schedule: "0 8 * * *"},
+		},
+		Nodes: map[string]spec.NodeSpec{
+			"process": {Path: "./nodes/process.ts"},
+		},
+	}
+
+	manifests := GenerateK8sManifests(wf, "test:latest", "default", DeployOptions{})
+
+	// Find the CronJob manifest
+	var cronContent string
+	for _, m := range manifests {
+		if m.Kind == "CronJob" {
+			cronContent = m.Content
+			break
+		}
+	}
+	if cronContent == "" {
+		t.Fatal("expected a CronJob manifest for cron trigger")
+	}
+
+	// Pod-level security context
+	if !strings.Contains(cronContent, "runAsNonRoot: true") {
+		t.Error("expected runAsNonRoot: true in CronJob pod security context")
+	}
+	if !strings.Contains(cronContent, "runAsUser: 65534") {
+		t.Error("expected runAsUser: 65534 in CronJob pod security context")
+	}
+	if !strings.Contains(cronContent, "type: RuntimeDefault") {
+		t.Error("expected seccompProfile type: RuntimeDefault in CronJob pod security context")
+	}
+
+	// Container-level security context
+	if !strings.Contains(cronContent, "readOnlyRootFilesystem: true") {
+		t.Error("expected readOnlyRootFilesystem: true in CronJob container security context")
+	}
+	if !strings.Contains(cronContent, "allowPrivilegeEscalation: false") {
+		t.Error("expected allowPrivilegeEscalation: false in CronJob container security context")
+	}
+	if !strings.Contains(cronContent, "- ALL") {
+		t.Error("expected capabilities drop ALL in CronJob container security context")
+	}
+
+	// Trigger role label on pod
+	if !strings.Contains(cronContent, "tentacular.dev/role: trigger") {
+		t.Error("expected tentacular.dev/role: trigger label on CronJob pod")
+	}
+}
+
+// TestE2E_CronJobTriggerEgressNetworkPolicy verifies that a CronJob workflow generates
+// a trigger NetworkPolicy allowing egress to the engine on port 8080 and to kube-dns.
+func TestE2E_CronJobTriggerEgressNetworkPolicy(t *testing.T) {
+	wf := &spec.Workflow{
+		Name:    "cron-netpol",
+		Version: "1.0",
+		Triggers: []spec.Trigger{
+			{Type: "cron", Schedule: "0 8 * * *"},
+		},
+		Nodes: map[string]spec.NodeSpec{
+			"process": {Path: "./nodes/process.ts"},
+		},
+	}
+
+	manifests := GenerateK8sManifests(wf, "test:latest", "tentacular-dev", DeployOptions{})
+
+	// Find the trigger NetworkPolicy manifest
+	var netpolContent string
+	var netpolName string
+	for _, m := range manifests {
+		if m.Kind == "NetworkPolicy" && strings.Contains(m.Name, "trigger") {
+			netpolContent = m.Content
+			netpolName = m.Name
+			break
+		}
+	}
+	if netpolContent == "" {
+		t.Fatal("expected a trigger NetworkPolicy manifest for cron workflow")
+	}
+	_ = netpolName
+
+	// Must select trigger pods
+	if !strings.Contains(netpolContent, "tentacular.dev/role: trigger") {
+		t.Error("expected podSelector for tentacular.dev/role: trigger")
+	}
+
+	// Must have egress to engine on port 8080
+	if !strings.Contains(netpolContent, "port: 8080") {
+		t.Error("expected egress port 8080 to workflow engine")
+	}
+
+	// Must have DNS egress
+	if !strings.Contains(netpolContent, "port: 53") {
+		t.Error("expected DNS egress port 53")
+	}
+	if !strings.Contains(netpolContent, "kube-dns") {
+		t.Error("expected kube-dns selector in DNS egress rule")
+	}
+
+	// Must have correct namespace
+	if !strings.Contains(netpolContent, "namespace: tentacular-dev") {
+		t.Error("expected namespace: tentacular-dev in trigger NetworkPolicy")
+	}
+
+	// Must declare Egress policy type
+	if !strings.Contains(netpolContent, "- Egress") {
+		t.Error("expected Egress in policyTypes")
+	}
+}
+
+// TestE2E_NoCronNoTriggerNetworkPolicy verifies that workflows without cron triggers
+// do NOT generate a trigger NetworkPolicy.
+func TestE2E_NoCronNoTriggerNetworkPolicy(t *testing.T) {
+	wf := &spec.Workflow{
+		Name:    "manual-only",
+		Version: "1.0",
+		Triggers: []spec.Trigger{
+			{Type: "manual"},
+		},
+		Nodes: map[string]spec.NodeSpec{
+			"process": {Path: "./nodes/process.ts"},
+		},
+	}
+
+	manifests := GenerateK8sManifests(wf, "test:latest", "default", DeployOptions{})
+
+	for _, m := range manifests {
+		if m.Kind == "NetworkPolicy" && strings.Contains(m.Name, "trigger") {
+			t.Errorf("unexpected trigger NetworkPolicy for manual-only workflow: %s", m.Name)
+		}
+	}
+}
+
 // TestE2E_DenoFlagsCommandStructure verifies the exact order and structure of command/args
 // entries in the generated Deployment YAML.
 func TestE2E_DenoFlagsCommandStructure(t *testing.T) {

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -358,6 +358,11 @@ func buildManifests(workflowDir string, wf *spec.Workflow, opts InternalDeployOp
 		manifests = append(manifests, *netpol)
 	}
 
+	// Add trigger egress NetworkPolicy if workflow has cron triggers
+	if triggerNetpol := k8s.GenerateTriggerNetworkPolicy(wf, namespace); triggerNetpol != nil {
+		manifests = append(manifests, *triggerNetpol)
+	}
+
 	// Add import map ConfigMap when workflow has jsr/npm module proxy dependencies
 	if k8s.HasModuleProxyDeps(wf) {
 		if importMap := k8s.GenerateImportMapWithNamespace(wf, namespace, proxyURL); importMap != nil {

--- a/pkg/k8s/importmap.go
+++ b/pkg/k8s/importmap.go
@@ -25,7 +25,7 @@ const DefaultModuleProxyURL = "http://esm-sh.tentacular-support.svc.cluster.loca
 // TODO: auto-sync from engine/deno.json at build time instead of hardcoding here.
 // Keep in sync with engine/deno.json whenever engine deps change.
 var engineDenoImports = map[string]string{
-	"tentacular":              "./engine/mod.ts",
+	"tentacular":              "./mod.ts",
 	"std/":                    "https://deno.land/std@0.224.0/",
 	"std/yaml":                "https://deno.land/std@0.224.0/yaml/mod.ts",
 	"std/path":                "https://deno.land/std@0.224.0/path/mod.ts",
@@ -39,8 +39,9 @@ var engineDenoImports = map[string]string{
 
 // GenerateImportMap produces a ConfigMap manifest containing a merged deno.json that
 // combines engine import entries with jsr:/npm: rewrites pointing to the in-cluster
-// module proxy. Mounted at /app/deno.json, it overrides the image-baked deno.json so
-// Deno auto-discovers it without needing --import-map (which would break engine imports).
+// module proxy. Mounted at /app/deno.json by GenerateK8sManifests, it overrides the
+// image-baked deno.json so Deno auto-discovers it from the /app entrypoint (mod.ts)
+// without needing --import-map (which would break engine imports).
 // Returns nil if the workflow has no jsr/npm dependencies.
 func GenerateImportMap(wf *spec.Workflow, proxyURL string) *builder.Manifest {
 	if wf.Contract == nil || len(wf.Contract.Dependencies) == 0 {


### PR DESCRIPTION
## Summary
- Fix import map path from `./engine/mod.ts` to `./mod.ts` and mount path to `/app/deno.json`
- Add PSA-compliant security contexts to proxy-prewarm init container and CronJob trigger
- Generate trigger egress NetworkPolicy for CronJob trigger pods (port 8080 + DNS)
- Add contract dependency scanning to `tntc secrets check`
- Document dual trigger NetworkPolicy implementation (import cycle constraint)

## Observation Coverage
| Obs | Fix |
|-----|-----|
| #4 | `secrets check` scans contract.dependencies auth.secret |
| #9 | PSA security contexts on init container + CronJob trigger |
| #16 | Import map path corrected |
| #19 | Trigger egress NetworkPolicy auto-generated |

## Test plan
- [x] `go test -count=1 ./...` — all packages pass
- [x] Import map test validates `./mod.ts` path
- [x] E2E security tests for init container and CronJob trigger PSA
- [x] Trigger NetworkPolicy tests (with/without cron triggers)
- [x] Contract secrets scanning tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)