### PR TITLE
fix: replace hardcoded namespace strings with constants

### DIFF
--- a/pkg/cli/cluster.go
+++ b/pkg/cli/cluster.go
@@ -39,7 +39,7 @@ After install, the MCP endpoint and token are saved to ~/.tentacular/config.yaml
 so subsequent tntc commands automatically find and use the MCP server.`,
 		RunE: runClusterInstall,
 	}
-	install.Flags().String("namespace", "tentacular-system", "Namespace to install MCP server into")
+	install.Flags().String("namespace", k8s.DefaultMCPNamespace, "Namespace to install MCP server into")
 	install.Flags().String("proxy-namespace", k8s.DefaultProxyNamespace, "Namespace to install module proxy into")
 	install.Flags().String("image", "", "MCP server image (default: "+k8s.DefaultMCPImage+")")
 	install.Flags().Bool("module-proxy", true, "Install esm.sh module proxy for jsr/npm dep resolution")

--- a/pkg/k8s/netpol.go
+++ b/pkg/k8s/netpol.go
@@ -67,15 +67,15 @@ func GenerateNetworkPolicy(wf *spec.Workflow, namespace string, proxyNamespace s
 	// Always include the control plane ingress rule so that wf_run and cron triggers
 	// from the MCP server in tentacular-system can reach the workflow on port 8080.
 	// Uses namespaceSelector instead of ipBlock for precise origin-namespace matching.
-	controlPlaneIngress := `  # Control plane ingress: allows wf_run and cron triggers from MCP server
+	controlPlaneIngress := fmt.Sprintf(`  # Control plane ingress: allows wf_run and cron triggers from MCP server
   - from:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: tentacular-system
+          kubernetes.io/metadata.name: %s
     ports:
     - protocol: TCP
       port: 8080
-`
+`, DefaultMCPNamespace)
 	ingressYAML := "  ingress:\n" + controlPlaneIngress
 	for _, rule := range ingressRules {
 		ingressYAML += "  - from:\n"


### PR DESCRIPTION
## Summary

- Replace raw `"tentacular-system"` string in netpol.go with `DefaultMCPNamespace` constant
- Replace raw `"tentacular-system"` string in cluster.go CLI flag default with `k8s.DefaultMCPNamespace`

## Test plan

- [x] `go test -count=1 ./...` -- 521 tests pass

Generated with [Claude Code](https://claude.com/claude-code)