### PR TITLE
feat: v0.3.0 E2E fixes, docs sync, kube-router/k0s detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scratch/
 .claude/
 .codex/
 .gemini/
+.mcp.json
 CLAUDE.md
 
 # IDE

--- a/openspec/changes/cluster-profile/tasks.md
+++ b/openspec/changes/cluster-profile/tasks.md
@@ -2,52 +2,54 @@
 
 ## WI-1: `pkg/k8s/profile.go`
 
-- [ ] Define `ClusterProfile`, `NodeInfo`, `RuntimeClass`, `CNIInfo`, `NetPolInfo`,
+- [x] Define `ClusterProfile`, `NodeInfo`, `RuntimeClass`, `CNIInfo`, `NetPolInfo`,
       `StorageClass`, `ExtensionSet`, `QuotaSummary`, `LimitRangeSummary` structs
-- [ ] Implement `(*Client).Profile(ctx, namespace string) (*ClusterProfile, error)`
-  - [ ] Collect K8s version via `Discovery().ServerVersion()`
-  - [ ] List nodes; detect distribution from node labels + kubeconfig context name
-  - [ ] List `NodeV1().RuntimeClasses()` + detect gVisor
-  - [ ] Detect CNI via kube-system pod labels
-  - [ ] List `StorageV1().StorageClasses()` + `StorageV1().CSIDrivers()`
-  - [ ] Detect NetworkPolicy support + InUse (list cluster-wide, count > 0)
-  - [ ] Detect ingress controllers (pod label scan, all namespaces)
-  - [ ] List CRDs via dynamic client (`apiextensions.k8s.io/v1`) + map to ExtensionSet
-  - [ ] Detect metrics server (kube-system pod label)
-  - [ ] List `CoreV1().ResourceQuotas(namespace)` + `CoreV1().LimitRanges(namespace)`
-  - [ ] Read namespace PSA labels
-  - [ ] Derive `Guidance` strings from collected data
-- [ ] Implement `(*ClusterProfile).Markdown() string` — renders the markdown format
-- [ ] Implement `(*ClusterProfile).JSON() string` — renders indented JSON
-- [ ] Write tests in `pkg/k8s/profile_test.go` covering guidance derivation and markdown output
+- [x] Implement `(*Client).Profile(ctx, namespace string) (*ClusterProfile, error)`
+  - [x] Collect K8s version via `Discovery().ServerVersion()`
+  - [x] List nodes; detect distribution from node labels + kubeconfig context name
+  - [x] List `NodeV1().RuntimeClasses()` + detect gVisor
+  - [x] Detect CNI via kube-system pod labels (calico, cilium, kube-router, weave, flannel, kindnet)
+  - [x] List `StorageV1().StorageClasses()` + `StorageV1().CSIDrivers()`
+  - [x] Detect NetworkPolicy support + InUse (list cluster-wide, count > 0)
+  - [x] Detect ingress controllers (pod label scan, all namespaces)
+  - [x] List CRDs via dynamic client (`apiextensions.k8s.io/v1`) + map to ExtensionSet
+  - [x] Detect metrics server (kube-system pod label)
+  - [x] List `CoreV1().ResourceQuotas(namespace)` + `CoreV1().LimitRanges(namespace)`
+  - [x] Read namespace PSA labels
+  - [x] Derive `Guidance` strings from collected data
+- [x] Implement `(*ClusterProfile).Markdown() string` — renders the markdown format
+- [x] Implement `(*ClusterProfile).JSON() string` — renders indented JSON
+- [x] Write tests in `pkg/k8s/profile_test.go` covering guidance derivation and markdown output
+- [x] Add kube-router CNI detection (k8s-app label, NetworkPolicy + egress supported)
+- [x] Add k0s distribution detection (node.k0sproject.io/role label)
 
 ## WI-2: `pkg/cli/profile.go`
 
-- [ ] Implement `NewProfileCmd() *cobra.Command` with flags: `--env`, `--all`,
+- [x] Implement `NewProfileCmd() *cobra.Command` with flags: `--env`, `--all`,
       `--output`, `--save`, `--force`
-- [ ] `runProfile`: resolve environment via `ResolveEnvironment()`, build client,
+- [x] `runProfile`: resolve environment via `ResolveEnvironment()`, build client,
       call `client.Profile()`, render output
-- [ ] `runProfileAll`: iterate all environments in `LoadConfig().Environments`, call
+- [x] `runProfileAll`: iterate all environments in `LoadConfig().Environments`, call
       `runProfileForEnv` for each, collect errors, exit non-zero only if all fail
-- [ ] `saveProfile`: write `.tentacular/envprofiles/<env>.md` and `<env>.json`
+- [x] `saveProfile`: write `.tentacular/envprofiles/<env>.md` and `<env>.json`
       (create dir if needed)
-- [ ] Freshness check: if profile file exists and `--force` not set and age < 1h, skip
+- [x] Freshness check: if profile file exists and `--force` not set and age < 1h, skip
       with message `Profile for 'prod' is fresh (generated X min ago). Use --force to rebuild.`
 
 ## WI-3: `pkg/cli/cluster.go`
 
-- [ ] Add `cluster.AddCommand(NewProfileCmd())` in `NewClusterCmd()`
+- [x] Add `cluster.AddCommand(NewProfileCmd())` in `NewClusterCmd()`
 
 ## WI-4: `pkg/cli/configure.go`
 
-- [ ] After writing config in `runConfigure`, iterate `cfg.Environments`
-- [ ] For each environment: resolve, create client, call `Profile()` with 30s timeout
-- [ ] On success: save to `.tentacular/envprofiles/<env>.{md,json}` and print confirmation
-- [ ] On failure (unreachable): print warning, continue — do not fail `configure`
+- [x] After writing config in `runConfigure`, iterate `cfg.Environments`
+- [x] For each environment: resolve, create client, call `Profile()` with 30s timeout
+- [x] On success: save to `.tentacular/envprofiles/<env>.{md,json}` and print confirmation
+- [x] On failure (unreachable): print warning, continue — do not fail `configure`
 
 ## WI-5: `docs/cli.md`
 
-- [ ] Add `tntc cluster profile` section with: description, all flags, examples,
+- [x] Add `tntc cluster profile` section with: description, all flags, examples,
       output format description, profile storage path, drift-detection guidance
 
 ## WI-6: `openspec/specs/cluster-profile/spec.md`
@@ -56,10 +58,8 @@
 
 ## WI-7: k8s4agents — `skills/tentacular/SKILL.md`
 
-- [ ] Create `skills/tentacular/SKILL.md` with:
-  - Skill header (name, version, description)
-  - Overview of `tntc` commands relevant to agents
-  - Initial setup workflow: `tntc configure` → auto-profiles all environments
-  - Pre-workflow-build step: load `.tentacular/envprofiles/<env>.md` as context
-  - Drift detection: list of signals + `tntc cluster profile --env <name> --save`
-  - Guidance interpretation: how to use each guidance string when designing tentacles
+- [x] Skill header, overview of `tntc` commands
+- [x] Initial setup workflow: `tntc configure` -> auto-profiles all environments
+- [x] Pre-workflow-build step: load `.tentacular/envprofiles/<env>.md` as context
+- [x] Drift detection: list of signals + `tntc cluster profile --env <name> --save`
+- [x] Guidance interpretation: how to use each guidance string when designing tentacles

--- a/openspec/changes/e2e-telemetry-validation/tasks.md
+++ b/openspec/changes/e2e-telemetry-validation/tasks.md
@@ -1,35 +1,35 @@
 ## 1. Test Fixtures
 
-- [ ] 1.1 Create engine/testing/fixtures/ directory with a two-node linear workflow (workflow.yaml + stub nodes) for success path testing
-- [ ] 1.2 Create error-path fixture with a workflow containing a node that throws an exception
-- [ ] 1.3 Create multi-node DAG fixture (A -> B, A -> C) for topological ordering validation
+- [x] 1.1 Create engine/testing/fixtures/ directory with a two-node linear workflow (workflow.yaml + stub nodes) for success path testing
+- [x] 1.2 Create error-path fixture with a workflow containing a node that throws an exception
+- [x] 1.3 Create multi-node DAG fixture (A -> B, A -> C) for topological ordering validation
 
 ## 2. Telemetry Sink E2E Tests
 
-- [ ] 2.1 Add integration test: SimpleExecutor with BasicSink records node-start and node-complete events for two-node workflow (4 total events)
-- [ ] 2.2 Add integration test: SimpleExecutor with BasicSink records node-error event with correct metadata for failing node
-- [ ] 2.3 Add integration test: SimpleExecutor with BasicSink records events in topological order for DAG fixture
-- [ ] 2.4 Add integration test: HTTP server records request-in and request-out events on POST /run
-- [ ] 2.5 Add integration test: engine-start event is present and is the first event in the ring buffer
+- [x] 2.1 Add integration test: SimpleExecutor with BasicSink records node-start and node-complete events for two-node workflow (4 total events)
+- [x] 2.2 Add integration test: SimpleExecutor with BasicSink records node-error event with correct metadata for failing node
+- [x] 2.3 Add integration test: SimpleExecutor with BasicSink records events in topological order for DAG fixture
+- [x] 2.4 Add integration test: HTTP server records request-in and request-out events on POST /run
+- [x] 2.5 Add integration test: engine-start event is present and is the first event in the ring buffer
 
 ## 3. Health Endpoint E2E Tests
 
-- [ ] 3.1 Add E2E test: start engine server on dynamic port, execute workflow, verify GET /health?detail=1 returns snapshot with total_events > 0, error_rate == 0, uptime_seconds > 0
-- [ ] 3.2 Add E2E test: execute failing workflow, verify GET /health?detail=1 returns error_rate > 0 and last_error with message and timestamp
-- [ ] 3.3 Add E2E test: verify total_events in snapshot matches expected count after two-node workflow execution
-- [ ] 3.4 Add E2E test: verify GET /health returns {"status":"ok"} (backwards compatibility)
-- [ ] 3.5 Add E2E test: verify GET /health?detail=0 returns {"status":"ok"}
+- [x] 3.1 Add E2E test: start engine server on dynamic port, execute workflow, verify GET /health?detail=1 returns snapshot with total_events > 0, error_rate == 0, uptime_seconds > 0
+- [x] 3.2 Add E2E test: execute failing workflow, verify GET /health?detail=1 returns error_rate > 0 and last_error with message and timestamp
+- [x] 3.3 Add E2E test: verify total_events in snapshot matches expected count after two-node workflow execution
+- [x] 3.4 Add E2E test: verify GET /health returns {"status":"ok"} (backwards compatibility)
+- [x] 3.5 Add E2E test: verify GET /health?detail=0 returns {"status":"ok"}
 
 ## 4. NetworkPolicy Integration Tests
 
-- [ ] 4.1 Add test: DeriveIngressRules for webhook workflow includes MCP ingress rule (tentacular-system namespace selector, port 8080) alongside webhook rule
-- [ ] 4.2 Add test: DeriveIngressRules for non-webhook workflow includes MCP ingress rule
-- [ ] 4.3 Add test: MCP ingress rule is present regardless of trigger type or contract configuration
-- [ ] 4.4 Add test: rendered NetworkPolicy YAML contains correct namespaceSelector matchLabels for tentacular-system
-- [ ] 4.5 Add test: rendered NetworkPolicy YAML parses as valid Kubernetes NetworkPolicy v1 structure
+- [x] 4.1 Add test: DeriveIngressRules for webhook workflow includes MCP ingress rule (tentacular-system namespace selector, port 8080) alongside webhook rule
+- [x] 4.2 Add test: DeriveIngressRules for non-webhook workflow includes MCP ingress rule
+- [x] 4.3 Add test: MCP ingress rule is present regardless of trigger type or contract configuration
+- [x] 4.4 Add test: rendered NetworkPolicy YAML contains correct namespaceSelector matchLabels for tentacular-system
+- [x] 4.5 Add test: rendered NetworkPolicy YAML parses as valid Kubernetes NetworkPolicy v1 structure
 
 ## 5. Verification
 
-- [ ] 5.1 Run Deno engine tests -- all pass including new E2E tests
-- [ ] 5.2 Run `go test ./pkg/spec/...` -- all pass including new integration tests
-- [ ] 5.3 Run `go test ./pkg/k8s/...` -- all pass including new YAML rendering tests
+- [x] 5.1 Run Deno engine tests -- all pass including new E2E tests
+- [x] 5.2 Run `go test ./pkg/spec/...` -- all pass including new integration tests
+- [x] 5.3 Run `go test ./pkg/k8s/...` -- all pass including new YAML rendering tests

--- a/openspec/changes/telemetry-basic-sink/tasks.md
+++ b/openspec/changes/telemetry-basic-sink/tasks.md
@@ -1,31 +1,31 @@
 ## 1. Telemetry Types and Sink Interface
 
-- [ ] 1.1 Add `TelemetryEvent` and `TelemetrySnapshot` types to `engine/types.ts`
-- [ ] 1.2 Create `engine/telemetry.ts` with `TelemetrySink` interface, `NoopSink`, and `BasicSink` (ring buffer, counters, error rate, uptime)
-- [ ] 1.3 Add `NewTelemetrySink(kind: string)` factory function in `engine/telemetry.ts`
+- [x] 1.1 Add `TelemetryEvent` and `TelemetrySnapshot` types to `engine/types.ts`
+- [x] 1.2 Create `engine/telemetry.ts` with `TelemetrySink` interface, `NoopSink`, and `BasicSink` (ring buffer, counters, error rate, uptime)
+- [x] 1.3 Add `NewTelemetrySink(kind: string)` factory function in `engine/telemetry.ts`
 
 ## 2. Telemetry Wiring
 
-- [ ] 2.1 Wire `TelemetrySink` into `SimpleExecutor` -- record `node-start`, `node-complete`, `node-error` events with node name in metadata
-- [ ] 2.2 Wire `TelemetrySink` into `server.ts` -- record `request-in`/`request-out` on `/run`, serve `TelemetrySnapshot` on `GET /health?detail=1`
-- [ ] 2.3 Wire `TelemetrySink` into `engine/triggers/nats.ts` -- record `nats-message` event with subject in metadata
-- [ ] 2.4 Wire `TelemetrySink` in `engine/main.ts` -- create sink from `TELEMETRY_SINK` env var (default `"basic"`), pass to executor/server/nats, record `engine-start` event
+- [x] 2.1 Wire `TelemetrySink` into `SimpleExecutor` -- record `node-start`, `node-complete`, `node-error` events with node name in metadata
+- [x] 2.2 Wire `TelemetrySink` into `server.ts` -- record `request-in`/`request-out` on `/run`, serve `TelemetrySnapshot` on `GET /health?detail=1`
+- [x] 2.3 Wire `TelemetrySink` into `engine/triggers/nats.ts` -- record `nats-message` event with subject in metadata
+- [x] 2.4 Wire `TelemetrySink` in `engine/main.ts` -- create sink from `TELEMETRY_SINK` env var (default `"basic"`), pass to executor/server/nats, record `engine-start` event
 
 ## 3. MCP Ingress NetworkPolicy Rule
 
-- [ ] 3.1 Add unconditional MCP ingress rule in `pkg/spec/derive.go` `DeriveIngressRules()` -- allow TCP 8080 from `tentacular-system` namespace via `namespaceSelector`
-- [ ] 3.2 Update `pkg/k8s/netpol.go` to render the new namespace-selector-only ingress rule
-- [ ] 3.3 Add tests in `pkg/spec/derive_test.go` for MCP ingress rule (both webhook and non-webhook workflows)
-- [ ] 3.4 Add tests in `pkg/k8s/netpol_test.go` for NetworkPolicy YAML output with MCP ingress rule
+- [x] 3.1 Add unconditional MCP ingress rule in `pkg/spec/derive.go` `DeriveIngressRules()` -- allow TCP 8080 from `tentacular-system` namespace via `namespaceSelector`
+- [x] 3.2 Update `pkg/k8s/netpol.go` to render the new namespace-selector-only ingress rule
+- [x] 3.3 Add tests in `pkg/spec/derive_test.go` for MCP ingress rule (both webhook and non-webhook workflows)
+- [x] 3.4 Add tests in `pkg/k8s/netpol_test.go` for NetworkPolicy YAML output with MCP ingress rule
 
 ## 4. Engine Tests
 
-- [ ] 4.1 Create `engine/telemetry_test.ts` -- unit tests for NoopSink, BasicSink (counters, ring buffer wrap, error rate, uptime, last error), and factory
-- [ ] 4.2 Add tests for `/health?detail=1` response in server tests
-- [ ] 4.3 Verify existing `/health` endpoint returns `{"status":"ok"}` unchanged (backwards compatibility)
+- [x] 4.1 Create `engine/telemetry_test.ts` -- unit tests for NoopSink, BasicSink (counters, ring buffer wrap, error rate, uptime, last error), and factory
+- [x] 4.2 Add tests for `/health?detail=1` response in server tests
+- [x] 4.3 Verify existing `/health` endpoint returns `{"status":"ok"}` unchanged (backwards compatibility)
 
 ## 5. Verification
 
-- [ ] 5.1 Run `go test ./pkg/spec/...` -- all pass
-- [ ] 5.2 Run `go test ./pkg/k8s/...` -- all pass
-- [ ] 5.3 Run Deno engine tests -- all pass
+- [x] 5.1 Run `go test ./pkg/spec/...` -- all pass
+- [x] 5.2 Run `go test ./pkg/k8s/...` -- all pass
+- [x] 5.3 Run Deno engine tests -- all pass

--- a/pkg/builder/e2e_security_test.go
+++ b/pkg/builder/e2e_security_test.go
@@ -144,7 +144,7 @@ func TestE2E_CronTriggerAnnotationOnDeployment(t *testing.T) {
 
 	// The cron schedule should appear as an annotation on the Deployment.
 	dep := manifests[0].Content
-	if !strings.Contains(dep, "tentacular.dev/cron-schedule: 0 8 * * *") {
+	if !strings.Contains(dep, `tentacular.dev/cron-schedule: "0 8 * * *"`) {
 		t.Error("expected cron-schedule annotation on Deployment with schedule")
 	}
 }

--- a/pkg/builder/k8s_test.go
+++ b/pkg/builder/k8s_test.go
@@ -287,7 +287,7 @@ func TestK8sManifestCronTriggerSingle(t *testing.T) {
 		}
 	}
 	dep := manifests[0].Content
-	if !strings.Contains(dep, "tentacular.dev/cron-schedule: 0 9 * * *") {
+	if !strings.Contains(dep, `tentacular.dev/cron-schedule: "0 9 * * *"`) {
 		t.Error("expected cron-schedule annotation on Deployment with schedule")
 	}
 }
@@ -343,7 +343,7 @@ func TestK8sManifestCronTriggerNamedScheduleAnnotation(t *testing.T) {
 	manifests := GenerateK8sManifests(wf, "named-cron:1-0", "default", DeployOptions{})
 
 	dep := manifests[0].Content
-	if !strings.Contains(dep, "tentacular.dev/cron-schedule: 0 9 * * *") {
+	if !strings.Contains(dep, `tentacular.dev/cron-schedule: "0 9 * * *"`) {
 		t.Error("expected cron-schedule annotation with schedule on Deployment")
 	}
 }
@@ -407,7 +407,7 @@ func TestK8sManifestCronTriggerAnnotationOnlyTwoManifests(t *testing.T) {
 		t.Fatalf("expected 2 manifests (Deployment+Service), got %d", len(manifests))
 	}
 	dep := manifests[0].Content
-	if !strings.Contains(dep, "tentacular.dev/cron-schedule: 0 9 * * *") {
+	if !strings.Contains(dep, `tentacular.dev/cron-schedule: "0 9 * * *"`) {
 		t.Error("expected cron-schedule annotation on Deployment")
 	}
 }
@@ -918,7 +918,7 @@ func TestBuildDeployAnnotationsCronScheduleSingle(t *testing.T) {
 		{Type: "cron", Schedule: "0 9 * * *"},
 	}
 	result := buildDeployAnnotations(nil, triggers)
-	if !strings.Contains(result, "tentacular.dev/cron-schedule: 0 9 * * *") {
+	if !strings.Contains(result, `tentacular.dev/cron-schedule: "0 9 * * *"`) {
 		t.Error("expected cron-schedule annotation with single schedule")
 	}
 }
@@ -930,7 +930,7 @@ func TestBuildDeployAnnotationsCronScheduleMultiple(t *testing.T) {
 		{Type: "cron", Schedule: "0 * * * *"},
 	}
 	result := buildDeployAnnotations(nil, triggers)
-	if !strings.Contains(result, "tentacular.dev/cron-schedule: 0 9 * * *,0 * * * *") {
+	if !strings.Contains(result, `tentacular.dev/cron-schedule: "0 9 * * *,0 * * * *"`) {
 		t.Errorf("expected comma-joined schedules in cron-schedule annotation, got: %q", result)
 	}
 }

--- a/pkg/k8s/e2e_security_test.go
+++ b/pkg/k8s/e2e_security_test.go
@@ -103,12 +103,12 @@ contract:
 	// Should have scoped --allow-env
 	foundScopedEnv := false
 	for _, flag := range denoFlags {
-		if flag == "--allow-env=DENO_DIR,HOME" {
+		if flag == "--allow-env=DENO_DIR,HOME,TELEMETRY_SINK" {
 			foundScopedEnv = true
 		}
 	}
 	if !foundScopedEnv {
-		t.Error("expected --allow-env=DENO_DIR,HOME in derived flags")
+		t.Error("expected --allow-env=DENO_DIR,HOME,TELEMETRY_SINK in derived flags")
 	}
 
 	// Step 4: Verify derived secrets

--- a/pkg/k8s/netpol.go
+++ b/pkg/k8s/netpol.go
@@ -42,9 +42,9 @@ func GenerateNetworkPolicy(wf *spec.Workflow, namespace string, proxyNamespace s
 		}
 	}
 
-	// Add module proxy egress rule when workflow has jsr/npm dependencies.
-	// Workflow pods route all jsr:/npm: imports through the in-cluster esm.sh service.
-	if HasModuleProxyDeps(wf) {
+	// Always add module proxy egress — engine jsr: deps must route through esm.sh.
+	// Workflow namespaces cannot reach external registries directly.
+	{
 		proxyEgress := fmt.Sprintf(`  # Module proxy (esm.sh): resolves jsr: and npm: imports
   - to:
     - namespaceSelector:

--- a/pkg/k8s/profile.go
+++ b/pkg/k8s/profile.go
@@ -283,6 +283,9 @@ func detectDistribution(nodes *corev1.NodeList) string {
 		if v, ok := labels["node.kubernetes.io/instance-type"]; ok && strings.HasPrefix(v, "k3s") {
 			return "k3s"
 		}
+		if _, ok := labels["node.k0sproject.io/role"]; ok {
+			return "k0s"
+		}
 	}
 	return "vanilla"
 }
@@ -296,6 +299,8 @@ func detectCNI(pods *corev1.PodList) CNIInfo {
 			return CNIInfo{Name: "calico", NetworkPolicySupported: true, EgressSupported: true}
 		case app == "cilium":
 			return CNIInfo{Name: "cilium", NetworkPolicySupported: true, EgressSupported: true}
+		case app == "kube-router":
+			return CNIInfo{Name: "kube-router", NetworkPolicySupported: true, EgressSupported: true}
 		case strings.Contains(name, "weave"):
 			return CNIInfo{Name: "weave", NetworkPolicySupported: true, EgressSupported: true}
 		case strings.Contains(name, "flannel"):

--- a/pkg/k8s/profile_test.go
+++ b/pkg/k8s/profile_test.go
@@ -46,6 +46,17 @@ func TestDetectDistribution_AKS(t *testing.T) {
 	}
 }
 
+func TestDetectDistribution_K0s(t *testing.T) {
+	nodes := &corev1.NodeList{Items: []corev1.Node{{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"node.k0sproject.io/role": "control-plane"},
+		},
+	}}}
+	if got := detectDistribution(nodes); got != "k0s" {
+		t.Errorf("expected k0s, got %s", got)
+	}
+}
+
 func TestDetectDistribution_Vanilla(t *testing.T) {
 	nodes := &corev1.NodeList{Items: []corev1.Node{{
 		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
@@ -115,6 +126,25 @@ func TestDetectCNI_Kindnet(t *testing.T) {
 	cni := detectCNI(pods)
 	if cni.Name != "kindnet" {
 		t.Errorf("expected kindnet, got %s", cni.Name)
+	}
+}
+
+func TestDetectCNI_KubeRouter(t *testing.T) {
+	pods := &corev1.PodList{Items: []corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kube-router-cq8ct",
+			Labels: map[string]string{"k8s-app": "kube-router", "tier": "node"},
+		},
+	}}}
+	cni := detectCNI(pods)
+	if cni.Name != "kube-router" {
+		t.Errorf("expected kube-router, got %s", cni.Name)
+	}
+	if !cni.NetworkPolicySupported {
+		t.Error("expected NetworkPolicy supported for kube-router")
+	}
+	if !cni.EgressSupported {
+		t.Error("expected egress supported for kube-router")
 	}
 }
 

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -19,7 +19,7 @@ type WfApplyParams struct {
 type WfApplyResult struct {
 	Status  string   `json:"status"`  // "created" | "updated" | "unchanged"
 	Applied []string `json:"applied"` // resource names applied
-	Updated bool     `json:"updated"` // true if any resource was updated vs created
+	Updated int      `json:"updated"` // count of resources updated (vs created)
 }
 
 // WfApply calls the wf_apply MCP tool to apply workflow manifests.

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -55,7 +55,7 @@ func TestWfApply(t *testing.T) {
 	h := makeToolServer(t, "wf_apply", WfApplyResult{
 		Status:  "created",
 		Applied: []string{"ConfigMap/my-wf", "Deployment/my-wf"},
-		Updated: false,
+		Updated: 0,
 	}, false)
 	defer h.Close()
 
@@ -258,7 +258,7 @@ func TestWfApply_Updated(t *testing.T) {
 	h := makeToolServer(t, "wf_apply", WfApplyResult{
 		Status:  "updated",
 		Applied: []string{"Deployment/my-wf"},
-		Updated: true,
+		Updated: 1,
 	}, false)
 	defer h.Close()
 
@@ -266,8 +266,8 @@ func TestWfApply_Updated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WfApply: %v", err)
 	}
-	if !result.Updated {
-		t.Error("expected updated=true")
+	if result.Updated == 0 {
+		t.Error("expected updated > 0")
 	}
 }
 

--- a/pkg/spec/derive_test.go
+++ b/pkg/spec/derive_test.go
@@ -327,8 +327,8 @@ func TestDeriveDenoFlagsFixedHostScoped(t *testing.T) {
 	}
 
 	// Should include scoped --allow-env
-	if allowEnvFlag != "--allow-env=DENO_DIR,HOME" {
-		t.Errorf("expected --allow-env=DENO_DIR,HOME, got %s", allowEnvFlag)
+	if allowEnvFlag != "--allow-env=DENO_DIR,HOME,TELEMETRY_SINK" {
+		t.Errorf("expected --allow-env=DENO_DIR,HOME,TELEMETRY_SINK, got %s", allowEnvFlag)
 	}
 }
 
@@ -516,16 +516,16 @@ func TestDeriveDenoFlagsScopedAllowEnv(t *testing.T) {
 		t.Fatal("expected non-nil flags")
 	}
 
-	// Should include scoped --allow-env=DENO_DIR,HOME
+	// Should include scoped --allow-env=DENO_DIR,HOME,TELEMETRY_SINK
 	foundAllowEnv := false
 	for _, flag := range flags {
-		if flag == "--allow-env=DENO_DIR,HOME" {
+		if flag == "--allow-env=DENO_DIR,HOME,TELEMETRY_SINK" {
 			foundAllowEnv = true
 			break
 		}
 	}
 
 	if !foundAllowEnv {
-		t.Errorf("expected --allow-env=DENO_DIR,HOME in derived flags, got %v", flags)
+		t.Errorf("expected --allow-env=DENO_DIR,HOME,TELEMETRY_SINK in derived flags, got %v", flags)
 	}
 }


### PR DESCRIPTION
## Summary

Final batch of E2E-validated fixes, documentation synchronization, and OpenSpec task completion for the v0.3.0 release. All changes validated against live k0s cluster with 4 deployed workflows (word-counter, hn-digest, uptime-prober, ai-news-roundup).

- Fix cron schedule YAML annotation quoting, import map generation, deno.land proxy routing
- Add kube-router CNI and k0s distribution detection to cluster profiling
- Synchronize all docs, skills, and OpenSpec artifacts with implemented code
- 527 Go tests passing across 6 packages

## Changes Since v0.2.0 (Full v0.3.0 Release Notes)

### New Features

| Feature | Description |
|---------|-------------|
| **In-memory telemetry sink** | `BasicSink` records engine events (node-start/complete/error, request-in/out, engine-start) in a ring buffer with counters and error rate |
| **Enhanced health endpoint** | `GET /health?detail=1` returns full `TelemetrySnapshot` with event trace, counters, uptime, `lastRunFailed`, `inFlight` |
| **MCP ingress NetworkPolicy** | All workflow NetworkPolicies include an ingress rule allowing the MCP server (tentacular-system) to reach `/health` on port 8080 |
| **In-process cron scheduler** | MCP server reads `tentacular.dev/cron-schedule` annotations from Deployments and fires HTTP POSTs via `robfig/cron/v3` -- replaces K8s CronJob generation |
| **Direct HTTP wf_run** | MCP `wf_run` tool POSTs directly to workflow ClusterIP service -- replaces API service proxy |
| **Always-generated import maps** | Import map ConfigMap generated for every deployment (engine jsr deps need proxy) -- not conditional on workflow contract |
| **deno.land/std proxy routing** | `rewriteDenoLandURL()` routes deno.land/std imports through esm.sh via `/gh/denoland/deno_std@version/path` |
| **kube-router CNI detection** | Cluster profiling detects kube-router (k0s default) via `k8s-app: kube-router` pod label |
| **k0s distribution detection** | Cluster profiling detects k0s via `node.k0sproject.io/role` node label |

### Bug Fixes

| Fix | Root Cause |
|-----|-----------|
| Cron schedule YAML annotation quoting | `*/5 * * * *` unquoted -- `*` is YAML alias character, `*/5` parsed as invalid alias |
| `TELEMETRY_SINK` in `--allow-env` | Engine reads `TELEMETRY_SINK` env var but DeriveDenoFlags only allowed `DENO_DIR,HOME` |
| `--allow-import` for Deno 2 | Deno 2 requires explicit `--allow-import` for module import sources; added `deno.land:443` + proxy host |
| `WfApplyResult.Updated` type mismatch | MCP server returns `updated` as int (count), CLI expected bool |
| Hardcoded namespace strings | Replaced with `DefaultProxyNamespace` and `DefaultModuleProxyURL` constants |
| Stale API service proxy references | Replaced with direct HTTP and namespaceSelector patterns |

### Architecture Changes

- **Control plane**: tentacular-system (MCP server) + tentacular-support (esm.sh proxy)
- **Data plane**: workflow namespaces with NetworkPolicy isolation
- **Cron**: Deployment annotation + MCP in-process scheduler (no CronJob pods)
- **Module resolution**: All imports route through esm.sh proxy -- no direct registry egress from workflow pods
- **Health model**: G/A/R (GREEN/AMBER/RED) classification via MCP `wf_health` and `wf_health_ns` tools

### Documentation Synchronized

- `docs/architecture.md`: Cron scheduler, import maps, Secret JSON format, TELEMETRY_SINK, k0s/kube-router
- `docs/esm-module-proxy.md`: Always-generated import maps, deno.land proxy routing, updated Deno flags
- `docs/known-issues.md`: 5 new entries for issues fixed in this release
- Skills: deployment-guide.md updated with module proxy, telemetry, cron scheduler, Secret JSON structure
- OpenSpec: telemetry-basic-sink (17/17), e2e-telemetry-validation (21/21), cluster-profile tasks marked complete

### E2E Test Results

| Workflow | Namespace | Result | Notes |
|----------|-----------|--------|-------|
| word-counter | e2e-test-wc | PASS | GREEN health, 9 telemetry events, full node trace |
| hn-digest | e2e-test-hn | PASS | GREEN, egress NetworkPolicy validated against live HN API |
| uptime-prober | e2e-test-up | PASS | GREEN, 6 automated cron fires at 5-min intervals |
| ai-news-roundup | tent-wfs | PASS | GREEN, 4-node DAG, GPT-5.2 summarization, Slack delivery 200 |

## Test plan

- [x] `go test ./pkg/...` -- 527 tests passing across 6 packages
- [x] Live cluster E2E with 4 workflows (word-counter, hn-digest, uptime-prober, ai-news-roundup)
- [x] Telemetry sink validated via `/health?detail=1` endpoint
- [x] MCP ingress NetworkPolicy validated (health probes reach workflow pods from tentacular-system)
- [x] In-process cron scheduler validated (6 automated fires at exact 5-min intervals)
- [x] Module proxy validated (all imports route through esm.sh, no direct deno.land egress)
- [x] K8s Secret JSON structure validated (openai.api_key, slack.webhook_url)

🤖 Generated with [Claude Code](https://claude.com/claude-code)