### PR TITLE
ci: add CI workflow with lint, test, and engine jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v7
+
+  test-go:
+    name: Go Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run Go tests
+        run: go test ./... -v -count=1 -race
+
+  test-engine:
+    name: Engine Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: "2.x"
+
+      - name: Run engine tests
+        working-directory: engine
+        run: deno test --allow-net --allow-read --allow-write=/tmp --allow-env
+
+  lint-engine:
+    name: Engine Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: "2.x"
+
+      - name: Lint
+        working-directory: engine
+        run: deno lint
+
+      - name: Format check
+        working-directory: engine
+        run: deno fmt --check


### PR DESCRIPTION
Go lint and tests run on every push to main and every PR. Engine tests and lint run Deno test suite and format check.

Lint and test-go are intended as required status checks. Engine jobs (test-engine, lint-engine) are informational.