### PR TITLE
fix: deployment session fixes (import map, netpol, SPIFFE)

### DIFF
--- a/pkg/builder/k8s.go
+++ b/pkg/builder/k8s.go
@@ -217,8 +217,11 @@ func GenerateK8sManifests(wf *spec.Workflow, imageTag, namespace string, opts De
 	// Always mount the import map — the engine has jsr: deps (e.g. @nats-io/transport-deno)
 	// that must route through the in-cluster module proxy. Workflow namespaces cannot reach
 	// external registries directly.
+	// Mount at /app/engine/deno.json because Deno discovers config by walking up from the
+	// entrypoint (/app/engine/main.ts) and the engine image bakes a deno.json at that path.
+	// Mounting at /app/deno.json would be shadowed by the closer /app/engine/deno.json.
 	importMapVolumeMount := `            - name: import-map
-              mountPath: /app/deno.json
+              mountPath: /app/engine/deno.json
               subPath: deno.json
               readOnly: true
 `

--- a/pkg/k8s/importmap.go
+++ b/pkg/k8s/importmap.go
@@ -91,6 +91,10 @@ func GenerateImportMap(wf *spec.Workflow, proxyURL string) *builder.Manifest {
 					imports[baseSpec+"@"+dep.Version] = proxyURL + proxyPath
 				}
 				imports[baseSpec] = proxyURL + proxyPath
+				// Also emit a bare specifier key so that
+				// `import { Client } from "@db/postgres"` is intercepted
+				// by the import map (Deno's jsr: protocol bypasses import maps).
+				imports[dep.Host] = proxyURL + proxyPath
 			case "npm":
 				// Same dual-key strategy for npm: specifiers.
 				baseSpec := "npm:" + dep.Host

--- a/pkg/k8s/netpol.go
+++ b/pkg/k8s/netpol.go
@@ -14,6 +14,9 @@ import (
 // When the workflow has jsr/npm dependencies, an egress rule to the in-cluster module
 // proxy (esm.sh in tentacular-support) is automatically added.
 func GenerateNetworkPolicy(wf *spec.Workflow, namespace, proxyNamespace string) *builder.Manifest {
+	if proxyNamespace == "" {
+		proxyNamespace = DefaultProxyNamespace
+	}
 	if wf.Contract == nil {
 		return nil
 	}

--- a/pkg/spec/derive.go
+++ b/pkg/spec/derive.go
@@ -340,7 +340,7 @@ func DeriveDenoFlags(c *Contract, proxyHost string) []string {
 		allowNetFlag,
 		"--allow-read=/app",
 		"--allow-write=/tmp",
-		"--allow-env=DENO_DIR,HOME,TELEMETRY_SINK",
+		"--allow-env=DENO_DIR,HOME,SPIFFE_ENDPOINT_SOCKET,SPIFFE_ID,SPIFFE_ID_PATH,SVID_CERT_PATH,TELEMETRY_SINK",
 	}
 
 	// Deno 2 requires explicit --allow-import permission for any host from which


### PR DESCRIPTION
## Summary
- Mount import map at /app/engine/deno.json (matches engine image layout, not /app/deno.json)
- Emit bare specifier keys in import map so `import { Client } from "@db/postgres"` works
- Default proxyNamespace in GenerateNetworkPolicy when empty
- Add SPIFFE env vars to Deno --allow-env for SPIRE CSI support

These fixes were discovered during the parallel deployment session that deployed 5 tentacles to the eastus cluster.

## Test plan
- [ ] Verify `tntc build` generates correct import map mount path
- [ ] Verify JSR packages resolve through module proxy
- [ ] Verify NetworkPolicy generates correctly with empty proxyNamespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)