### PR TITLE
refactor: rename tentacular-catalog to tentacular-scaffolds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Tentacular is a security-first, agent-centric, DAG-based workflow builder and ru
 | [tentacular](https://github.com/randybias/tentacular) | Go CLI (`tntc`) + Deno workflow engine (this repo) |
 | [tentacular-mcp](https://github.com/randybias/tentacular-mcp) | In-cluster MCP server (Go, Helm chart) |
 | [tentacular-skill](https://github.com/randybias/tentacular-skill) | Agent skill definition (Markdown) |
-| [tentacular-catalog](https://github.com/randybias/tentacular-catalog) | Workflow template catalog (TypeScript/Deno) |
+| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | Scaffold quickstart library (TypeScript/Deno) |
 
 ## System Architecture
 
@@ -25,7 +25,7 @@ Developer / AI Agent
     Kubernetes API
         |
     Workflow Pods             <-- Deno engine from this repo's engine/
-        (gVisor sandbox)         Templates from tentacular-catalog
+        (gVisor sandbox)         Scaffolds from tentacular-scaffolds
 ```
 
 The CLI has zero direct Kubernetes API access. All cluster operations route through the MCP server via authenticated HTTP.
@@ -38,7 +38,7 @@ Before making changes, read the **[Architecture docs](https://randybias.github.i
 
 - **Go CLI** (`cmd/tntc/`, `pkg/`) — lifecycle management, K8s operations via MCP
 - **Deno Engine** (`engine/`) — DAG compilation and execution
-- **Template Catalog** — workflow templates available via `tntc catalog list` from [tentacular-catalog](https://github.com/randybias/tentacular-catalog)
+- **Scaffold Library** — scaffold quickstarts available via `tntc scaffold list` from [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds)
 - **Infrastructure** (`deploy/`) — gVisor setup scripts and K8s resources
 
 ## Key Commands
@@ -78,7 +78,7 @@ Changes in this repo often require updates in other repos:
 
 - **New MCP tool:** handler in `tentacular-mcp/pkg/tools/` -> client method in `pkg/mcp/tools.go` -> CLI command in `pkg/cli/` -> skill docs in `tentacular-skill/`
 - **Contract/spec changes:** parser in `pkg/spec/` -> engine types in `engine/types.ts` -> builder in `pkg/builder/` -> skill docs in `tentacular-skill/`
-- **New workflow template:** template in `tentacular-catalog/templates/`
+- **New scaffold quickstart:** quickstart in `tentacular-scaffolds/quickstarts/`
 - **Security model changes:** may touch `pkg/builder/`, `tentacular-mcp/pkg/k8s/`, and `tentacular-skill/`
 
 ## Commit Messages

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Three components form the system: a Go CLI manages the full lifecycle, an in-clu
 | [tentacular](https://github.com/randybias/tentacular) | Go CLI (`tntc`) + Deno workflow engine |
 | [tentacular-mcp](https://github.com/randybias/tentacular-mcp) | In-cluster MCP server (Helm chart, 32 tools) |
 | [tentacular-skill](https://github.com/randybias/tentacular-skill) | Agent skill definition for AI assistants |
-| [tentacular-catalog](https://github.com/randybias/tentacular-catalog) | [Workflow template catalog](https://randybias.github.io/tentacular-catalog) |
+| [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) | [Scaffold quickstart library](https://randybias.github.io/tentacular-scaffolds) |
 | [tentacular-docs](https://github.com/randybias/tentacular-docs) | [Documentation site](https://randybias.github.io/tentacular-docs) |
 
 ## Documentation
@@ -153,24 +153,24 @@ export default async function run(ctx: Context, input: unknown): Promise<unknown
 
 See [Node Contract reference](https://randybias.github.io/tentacular-docs/reference/node-contract/) for the full Context API, auth patterns, and testing fixtures.
 
-## Template Catalog
+## Scaffold Library
 
-Production-ready workflow templates are available in the [tentacular-catalog](https://github.com/randybias/tentacular-catalog) ([browse online](https://randybias.github.io/tentacular-catalog)):
+Production-ready scaffold quickstarts are available in [tentacular-scaffolds](https://github.com/randybias/tentacular-scaffolds) ([browse online](https://randybias.github.io/tentacular-scaffolds)):
 
 ```bash
-# Browse available templates
-tntc catalog list
-tntc catalog search monitoring
-tntc catalog info hn-digest
+# Browse available scaffolds
+tntc scaffold list
+tntc scaffold search monitoring
+tntc scaffold info hn-digest
 
-# Scaffold from a template
-tntc catalog init hn-digest my-news-digest
+# Scaffold from a quickstart
+tntc scaffold init hn-digest my-news-digest
 cd my-news-digest
 tntc validate
 tntc dev
 ```
 
-| Template | Description | Complexity |
+| Scaffold | Description | Complexity |
 |----------|-------------|-----------|
 | `word-counter` | Simple word counting example | simple |
 | `hn-digest` | Fetch and filter top Hacker News stories | moderate |
@@ -179,7 +179,7 @@ tntc dev
 | `pr-review` | Automated PR review with parallel security scans | advanced |
 | `cluster-health-collector` | Collect K8s cluster health, store to Postgres | moderate |
 
-See `tntc catalog list` for the full catalog or [Catalog Usage guide](https://randybias.github.io/tentacular-docs/guides/catalog-usage/).
+See `tntc scaffold list` for the full library or [Catalog Usage guide](https://randybias.github.io/tentacular-docs/guides/catalog-usage/).
 
 ## Architecture
 
@@ -188,7 +188,7 @@ See `tntc catalog list` for the full catalog or [Catalog Usage guide](https://ra
 | `cmd/tntc/` | CLI entry point |
 | `pkg/` | Go packages: spec parser, builder, MCP client, CLI commands |
 | `engine/` | Deno TypeScript engine: compiler, executor, context, server, telemetry |
-| `pkg/catalog/` | Catalog client for fetching workflow templates |
+| `pkg/catalog/` | Catalog client for fetching scaffold quickstarts |
 | `deploy/` | Infrastructure scripts (gVisor installation, RuntimeClass) |
 
 ### Namespace Model

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,8 +72,8 @@ Completed items, most recent first.
 
 | Item | Completed | Notes |
 |------|-----------|-------|
-| tntc init + catalog init | 2026-02 | Scaffold command and catalog-based template initialization |
-| Workflow catalog commands | 2026-02 | `tntc catalog list`, `tntc catalog init <template>` |
+| tntc init + scaffold init | 2026-02 | Scaffold command and scaffold-based quickstart initialization |
+| Workflow scaffold commands | 2026-02 | `tntc scaffold list`, `tntc scaffold init <scaffold>` |
 | Release pipeline | 2026-02 | GoReleaser, install.sh, stable.txt, version package |
 
 ### 2026-02 — Core Fixes and Features
@@ -95,4 +95,4 @@ Completed items, most recent first.
 | `--allow-read` path widened | 2026-02 | Includes `/var/run/secrets` for SA tokens and CA certs |
 | `--unstable-net` flag added | 2026-02 | Enables `Deno.createHttpClient()` for custom TLS |
 | Version label YAML quoting | 2026-02 | Prevents semver strings from being parsed as floats |
-| Example workflows migration | 2026-02 | Consolidated to `tentacular-catalog` repo |
+| Example workflows migration | 2026-02 | Consolidated to `tentacular-scaffolds` repo |

--- a/pkg/catalog/client.go
+++ b/pkg/catalog/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultBaseURL  = "https://raw.githubusercontent.com/randybias/tentacular-catalog/main"
+	DefaultBaseURL  = "https://raw.githubusercontent.com/randybias/tentacular-scaffolds/main"
 	DefaultCacheTTL = 1 * time.Hour
 )
 
@@ -60,7 +60,7 @@ func NewClient(cfg CatalogConfig) *Client {
 func (c *Client) FetchIndex(noCache bool) (*CatalogIndex, error) {
 	cachePath := ""
 	if c.CacheDir != "" {
-		cachePath = filepath.Join(c.CacheDir, "catalog.yaml")
+		cachePath = filepath.Join(c.CacheDir, "scaffolds-index.yaml")
 	}
 
 	// Try cache first
@@ -79,7 +79,7 @@ func (c *Client) FetchIndex(noCache bool) (*CatalogIndex, error) {
 	}
 
 	// Fetch from remote
-	url := c.BaseURL + "/catalog.yaml"
+	url := c.BaseURL + "/scaffolds-index.yaml"
 	data, err := c.httpGet(url)
 	if err != nil {
 		return nil, fmt.Errorf("fetching catalog index: %w", err)


### PR DESCRIPTION
## Summary
- Update DefaultBaseURL in pkg/catalog/client.go to point to tentacular-scaffolds
- Update all AGENTS.md, README.md, roadmap references
- Part of the scaffold lifecycle redesign (repo was renamed on GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)