### PR TITLE
feat: surface workflow description in tntc list and deploy annotations

### DIFF
--- a/pkg/builder/k8s.go
+++ b/pkg/builder/k8s.go
@@ -125,13 +125,16 @@ func sanitizeAnnotationValue(v string) string {
 	return strings.TrimSpace(v)
 }
 
-// buildDeployAnnotations converts workflow metadata and cron triggers into a YAML
-// annotations block. Returns empty string if all fields are empty.
+// buildDeployAnnotations converts workflow metadata, description, and cron triggers
+// into a YAML annotations block. Returns empty string if all fields are empty.
 // Values are sanitized to prevent YAML injection via newlines or special characters.
 // If triggers contains cron triggers, a tentacular.io/cron-schedule annotation is
 // added with comma-separated schedules (one per cron trigger).
-func buildDeployAnnotations(meta *spec.WorkflowMetadata, triggers []spec.Trigger) string {
+func buildDeployAnnotations(meta *spec.WorkflowMetadata, triggers []spec.Trigger, description string) string {
 	var lines []string
+	if v := sanitizeAnnotationValue(description); v != "" {
+		lines = append(lines, "    tentacular.io/description: "+v)
+	}
 	if meta != nil {
 		if meta.Group != "" {
 			if v := sanitizeAnnotationValue(meta.Group); v != "" {
@@ -342,7 +345,7 @@ metadata:
         - name: tmp
           emptyDir:
             sizeLimit: 512Mi
-%s`, wf.Name, namespace, labels, buildDeployAnnotations(wf.Metadata, wf.Triggers), wf.Name, labels, runtimeClassLine, imageTag, imagePullPolicy, commandArgsBlock, importMapVolumeMount, wf.Name, strings.Join(configMapItems, "\n"), wf.Name, importMapVolume)
+%s`, wf.Name, namespace, labels, buildDeployAnnotations(wf.Metadata, wf.Triggers, wf.Description), wf.Name, labels, runtimeClassLine, imageTag, imagePullPolicy, commandArgsBlock, importMapVolumeMount, wf.Name, strings.Join(configMapItems, "\n"), wf.Name, importMapVolume)
 
 	manifests = append(manifests, Manifest{
 		Kind: "Deployment", Name: wf.Name, Content: deployment,
@@ -364,7 +367,7 @@ metadata:
     - port: 8080
       targetPort: 8080
       protocol: TCP
-`, wf.Name, namespace, labels, buildDeployAnnotations(wf.Metadata, nil), wf.Name)
+`, wf.Name, namespace, labels, buildDeployAnnotations(wf.Metadata, nil, wf.Description), wf.Name)
 
 	manifests = append(manifests, Manifest{
 		Kind: "Service", Name: wf.Name, Content: service,

--- a/pkg/builder/k8s_annotations_test.go
+++ b/pkg/builder/k8s_annotations_test.go
@@ -329,7 +329,7 @@ metadata:
 
 // TestBuildDeployAnnotationsNil verifies nil metadata with no triggers returns empty string.
 func TestBuildDeployAnnotationsNil(t *testing.T) {
-	result := buildDeployAnnotations(nil, nil)
+	result := buildDeployAnnotations(nil, nil, "")
 	if result != "" {
 		t.Errorf("expected empty string for nil metadata and no triggers, got %q", result)
 	}
@@ -337,7 +337,7 @@ func TestBuildDeployAnnotationsNil(t *testing.T) {
 
 // TestBuildDeployAnnotationsEmpty verifies empty struct with no triggers returns empty string.
 func TestBuildDeployAnnotationsEmpty(t *testing.T) {
-	result := buildDeployAnnotations(&spec.WorkflowMetadata{}, nil)
+	result := buildDeployAnnotations(&spec.WorkflowMetadata{}, nil, "")
 	if result != "" {
 		t.Errorf("expected empty string for empty metadata struct and no triggers, got %q", result)
 	}
@@ -346,7 +346,7 @@ func TestBuildDeployAnnotationsEmpty(t *testing.T) {
 // TestBuildDeployAnnotationsGroupOnly verifies annotations block with just group.
 func TestBuildDeployAnnotationsGroupOnly(t *testing.T) {
 	meta := &spec.WorkflowMetadata{Group: "platform-team"}
-	result := buildDeployAnnotations(meta, nil)
+	result := buildDeployAnnotations(meta, nil, "")
 	if !strings.Contains(result, "annotations:") {
 		t.Error("expected 'annotations:' in result")
 	}
@@ -368,7 +368,7 @@ func TestBuildDeployAnnotationsAllFields(t *testing.T) {
 		Tags:        []string{"etl", "daily", "reporting"},
 		Environment: "production",
 	}
-	result := buildDeployAnnotations(meta, nil)
+	result := buildDeployAnnotations(meta, nil, "")
 	if !strings.Contains(result, "tentacular.io/group: platform-team") {
 		t.Error("expected tentacular.io/group annotation")
 	}
@@ -388,7 +388,7 @@ func TestBuildDeployAnnotationsSingleTag(t *testing.T) {
 	meta := &spec.WorkflowMetadata{
 		Tags: []string{"etl"},
 	}
-	result := buildDeployAnnotations(meta, nil)
+	result := buildDeployAnnotations(meta, nil, "")
 	if !strings.Contains(result, "tentacular.io/tags: etl") {
 		t.Error("expected tentacular.io/tags: etl")
 	}
@@ -402,7 +402,7 @@ func TestBuildDeployAnnotationsCronSchedule(t *testing.T) {
 	triggers := []spec.Trigger{
 		{Type: "cron", Schedule: "0 9 * * *"},
 	}
-	result := buildDeployAnnotations(nil, triggers)
+	result := buildDeployAnnotations(nil, triggers, "")
 	if !strings.Contains(result, `tentacular.io/cron-schedule: "0 9 * * *"`) {
 		t.Error("expected tentacular.io/cron-schedule annotation")
 	}

--- a/pkg/builder/k8s_test.go
+++ b/pkg/builder/k8s_test.go
@@ -854,14 +854,14 @@ func TestDeploymentImportMapMountPath(t *testing.T) {
 }
 
 func TestBuildDeployAnnotationsNilMetadata(t *testing.T) {
-	result := buildDeployAnnotations(nil, nil)
+	result := buildDeployAnnotations(nil, nil, "")
 	if result != "" {
 		t.Errorf("expected empty string for nil metadata and no triggers, got %q", result)
 	}
 }
 
 func TestBuildDeployAnnotationsAllEmpty(t *testing.T) {
-	result := buildDeployAnnotations(&spec.WorkflowMetadata{}, nil)
+	result := buildDeployAnnotations(&spec.WorkflowMetadata{}, nil, "")
 	if result != "" {
 		t.Errorf("expected empty string for empty metadata struct and no triggers, got %q", result)
 	}
@@ -873,7 +873,7 @@ func TestBuildDeployAnnotationsFullMetadata(t *testing.T) {
 		Tags:        []string{"production", "critical"},
 		Environment: "prod",
 	}
-	result := buildDeployAnnotations(meta, nil)
+	result := buildDeployAnnotations(meta, nil, "")
 	if !strings.Contains(result, "tentacular.io/group: platform-team") {
 		t.Error("expected group annotation")
 	}
@@ -896,7 +896,7 @@ func TestBuildDeployAnnotationsPartialMetadata(t *testing.T) {
 		Group: "data-team",
 		// Tags, Environment intentionally omitted
 	}
-	result := buildDeployAnnotations(meta, nil)
+	result := buildDeployAnnotations(meta, nil, "")
 	if !strings.Contains(result, "tentacular.io/group: data-team") {
 		t.Error("expected group annotation")
 	}
@@ -915,7 +915,7 @@ func TestBuildDeployAnnotationsCronScheduleSingle(t *testing.T) {
 	triggers := []spec.Trigger{
 		{Type: "cron", Schedule: "0 9 * * *"},
 	}
-	result := buildDeployAnnotations(nil, triggers)
+	result := buildDeployAnnotations(nil, triggers, "")
 	if !strings.Contains(result, `tentacular.io/cron-schedule: "0 9 * * *"`) {
 		t.Error("expected cron-schedule annotation with single schedule")
 	}
@@ -930,7 +930,7 @@ func TestBuildDeployAnnotationsCronScheduleMultiple(t *testing.T) {
 		{Type: "manual"},
 		{Type: "cron", Schedule: "0 * * * *"},
 	}
-	result := buildDeployAnnotations(nil, triggers)
+	result := buildDeployAnnotations(nil, triggers, "")
 	if !strings.Contains(result, `tentacular.io/cron-schedule: "0 9 * * *,0 * * * *"`) {
 		t.Errorf("expected comma-joined schedules in cron-schedule annotation, got: %q", result)
 	}
@@ -940,7 +940,7 @@ func TestBuildDeployAnnotationsNewlineInjectionBlocked(t *testing.T) {
 	meta := &spec.WorkflowMetadata{
 		Group: "foo\n    injected.key: evil-value",
 	}
-	result := buildDeployAnnotations(meta, nil)
+	result := buildDeployAnnotations(meta, nil, "")
 
 	// Verify no additional YAML lines were injected. After sanitization the
 	// newlines are removed, so the only annotation lines should be

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -48,7 +48,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("%-24s %-8s %-16s %-10s %-10s %s\n", "NAME", "VERSION", "NAMESPACE", "STATUS", "REPLICAS", "AGE")
+	fmt.Printf("%-24s %-8s %-16s %-10s %-10s %-6s %s\n", "NAME", "VERSION", "NAMESPACE", "STATUS", "REPLICAS", "AGE", "DESCRIPTION")
 	for _, w := range workflows {
 		status := "not ready"
 		if w.Ready {
@@ -60,10 +60,21 @@ func runList(cmd *cobra.Command, args []string) error {
 				age = formatAge(time.Since(t))
 			}
 		}
-		fmt.Printf("%-24s %-8s %-16s %-10s %d/%d        %s\n", w.Name, w.Version, w.Namespace, status, w.Available, w.Replicas, age)
+		desc := truncateString(w.Description, 40)
+		fmt.Printf("%-24s %-8s %-16s %-10s %d/%-9d %-6s %s\n", w.Name, w.Version, w.Namespace, status, w.Available, w.Replicas, age, desc)
 	}
 
 	return nil
+}
+
+func truncateString(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
 }
 
 func formatAge(d time.Duration) string {

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -180,6 +180,7 @@ type WfListParams struct {
 // WfListItem represents a single workflow in the list response.
 type WfListItem struct {
 	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 	Namespace   string `json:"namespace"`
 	Version     string `json:"version,omitempty"`
 	Owner       string `json:"owner,omitempty"`


### PR DESCRIPTION
## Summary
- Write `tentacular.io/description` annotation on Deployments during deploy
- Add Description field to WfListItem struct
- Display description column in `tntc list` table output (truncated to 40 chars)
- Full description in JSON output

Closes #81 (CLI side — MCP server companion PR at randybias/tentacular-mcp)

## Test plan
- [x] `go test ./pkg/builder/...` passes
- [x] `go test ./pkg/mcp/...` passes
- [x] Description annotation written on deploy
- [x] Table output shows truncated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)