### PR TITLE
fix: quote sidecar command/args in K8s manifests

### DIFF
--- a/pkg/builder/k8s.go
+++ b/pkg/builder/k8s.go
@@ -195,15 +195,15 @@ func buildSidecarContainers(sidecars []spec.SidecarSpec) string {
 		if len(sc.Command) > 0 {
 			sb.WriteString("          command:\n")
 			for _, c := range sc.Command {
-				fmt.Fprintf(&sb, "            - %s\n", c)
+				fmt.Fprintf(&sb, "            - %q\n", c)
 			}
 		}
 
-		// Args (optional)
+		// Args (optional — always quote to prevent YAML type coercion)
 		if len(sc.Args) > 0 {
 			sb.WriteString("          args:\n")
 			for _, a := range sc.Args {
-				fmt.Fprintf(&sb, "            - %s\n", a)
+				fmt.Fprintf(&sb, "            - %q\n", a)
 			}
 		}
 


### PR DESCRIPTION
## Summary
- YAML type coercion causes numeric args (e.g. port `"3030"`) to be written as bare integers in the generated K8s manifest, which K8s API rejects with `cannot unmarshal number into Go struct field Container.spec.template.spec.containers.args of type string`
- Use `%q` formatting for both `command` and `args` entries in `buildSidecarContainers()` to always emit quoted strings

Found during v0.7.0-rc.1 E2E testing of the doc-converter scaffold (pandoc sidecar with `args: ["--port", "3030"]`).

## Test plan
- [x] All 10 sidecar builder tests pass
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)