### PR TITLE
fix: scaffold init fetches public scaffold files on-demand

### DIFF
--- a/pkg/cli/scaffold_init.go
+++ b/pkg/cli/scaffold_init.go
@@ -68,7 +68,7 @@ func runScaffoldInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Copy scaffold files
-	if copyErr := copyScaffoldFiles(entry, outDir); copyErr != nil {
+	if copyErr := copyScaffoldFiles(entry, outDir, client); copyErr != nil {
 		return copyErr
 	}
 
@@ -137,12 +137,53 @@ func resolveOutDir(dirOverride, tentacleName string) (string, error) {
 }
 
 // copyScaffoldFiles copies all files from entry's source directory to outDir.
-// For public scaffolds (no local Path), it returns an error directing users to sync.
-func copyScaffoldFiles(entry *scaffold.ScaffoldEntry, outDir string) error {
+// For public scaffolds whose Path is a remote-relative path (not a local directory),
+// files are fetched on-demand from the scaffold client.
+func copyScaffoldFiles(entry *scaffold.ScaffoldEntry, outDir string, client *scaffold.Client) error {
 	if entry.Path == "" {
-		return fmt.Errorf("scaffold '%s' has no local path; run 'tntc scaffold sync' first", entry.Name)
+		return fmt.Errorf("scaffold '%s' has no local path and no remote path; run 'tntc scaffold sync' first", entry.Name)
 	}
-	return copyScaffoldDir(entry.Path, outDir)
+
+	// If the path exists locally (private scaffold or previously synced), copy from disk.
+	if info, err := os.Stat(entry.Path); err == nil && info.IsDir() {
+		return copyScaffoldDir(entry.Path, outDir)
+	}
+
+	// Public scaffold: fetch files on-demand from the remote repo.
+	if len(entry.Files) == 0 {
+		return fmt.Errorf("scaffold '%s' has no files listed in the index", entry.Name)
+	}
+	return fetchScaffoldFiles(entry, outDir, client)
+}
+
+// fetchScaffoldFiles downloads each file listed in entry.Files from the
+// remote scaffolds repo and writes them to outDir preserving directory structure.
+func fetchScaffoldFiles(entry *scaffold.ScaffoldEntry, outDir string, client *scaffold.Client) error {
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	for _, relPath := range entry.Files {
+		// Hard-exclude .secrets.yaml; only .secrets.yaml.example is safe to copy.
+		if filepath.Base(relPath) == ".secrets.yaml" {
+			continue
+		}
+
+		remotePath := entry.Path + "/" + relPath
+		data, err := client.FetchFile(remotePath)
+		if err != nil {
+			return fmt.Errorf("fetching %s: %w", relPath, err)
+		}
+
+		target := filepath.Join(outDir, relPath)
+		if mkErr := os.MkdirAll(filepath.Dir(target), 0o700); mkErr != nil {
+			return fmt.Errorf("creating directory for %s: %w", relPath, mkErr)
+		}
+		if writeErr := os.WriteFile(target, data, 0o600); writeErr != nil { //nolint:gosec // scaffold file under validated outDir
+			return fmt.Errorf("writing %s: %w", relPath, writeErr)
+		}
+	}
+	return nil
 }
 
 // copyScaffoldDir recursively copies src into dst, preserving directory structure.

--- a/pkg/cli/scaffold_init_test.go
+++ b/pkg/cli/scaffold_init_test.go
@@ -21,6 +21,8 @@ package cli
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -447,15 +449,14 @@ func TestScaffoldInitPrivatePublicPrecedence(t *testing.T) {
 	}
 }
 
-// TestScaffoldInitSourcePublic verifies that --source=public skips private
-// scaffolds and searches the public index. Since public scaffolds don't have
-// local files until after sync, it returns a descriptive "sync first" error.
-func TestScaffoldInitSourcePublic(t *testing.T) {
+// TestScaffoldInitSourcePublicNoPath verifies that a public scaffold with
+// neither a local path nor a remote path returns a descriptive error.
+func TestScaffoldInitSourcePublicNoPath(t *testing.T) {
 	// Set up a private scaffold that should be ignored.
 	home, _ := scaffoldTestFixture(t, "uptime-tracker", "")
 	setTestHome(t, home)
 
-	// Also write a matching public index entry (no local path).
+	// Public index entry with no path and no files.
 	cacheDir := filepath.Join(home, ".tentacular", "cache")
 	makeIndexFileAtPath(t, filepath.Join(cacheDir, "scaffolds-index.yaml"), []scaffold.ScaffoldEntry{
 		{
@@ -474,16 +475,110 @@ func TestScaffoldInitSourcePublic(t *testing.T) {
 		map[string]string{"dir": outDir, "source": "public"},
 		map[string]bool{"no-params": true},
 	)
-	// Public scaffold has no local Path (sync hasn't downloaded files).
-	// Expected: error mentioning "sync" (not "not found").
 	if err == nil {
-		t.Fatal("expected error for public scaffold without local files, got nil")
+		t.Fatal("expected error for public scaffold without path or files, got nil")
 	}
-	if !strings.Contains(err.Error(), "sync") {
-		t.Errorf("expected 'sync' in error message (public scaffold not yet downloaded), got: %v", err)
+	if !strings.Contains(err.Error(), "no local path") {
+		t.Errorf("expected 'no local path' in error message, got: %v", err)
 	}
-	// Must NOT say "not found" -- scaffold was found in the index but needs sync.
-	if strings.Contains(err.Error(), "not found") {
-		t.Errorf("scaffold should be found in public index but need sync, got: %v", err)
+}
+
+// TestScaffoldInitPublicFetch verifies that a public scaffold with a remote
+// path and file list fetches files on-demand from the remote URL.
+func TestScaffoldInitPublicFetch(t *testing.T) {
+	// Start a test HTTP server serving scaffold files.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		files := map[string]string{
+			"/quickstarts/web-monitor/workflow.yaml":  "name: web-monitor\nversion: \"1.0\"\ntriggers:\n  - type: manual\nnodes:\n  probe:\n    path: ./nodes/probe.ts\n",
+			"/quickstarts/web-monitor/scaffold.yaml":  "name: web-monitor\nversion: \"1.0\"\nauthor: test\ncategory: monitoring\n",
+			"/quickstarts/web-monitor/nodes/probe.ts": "export default async function run(ctx, input) { return {}; }\n",
+			"/scaffolds-index.yaml":                   "", // not needed for this test
+		}
+		content, ok := files[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(content))
+	}))
+	defer ts.Close()
+
+	home := t.TempDir()
+	setTestHome(t, home)
+
+	// Write config pointing scaffold URL to test server.
+	configDir := filepath.Join(home, ".tentacular")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configContent := "scaffold:\n  url: " + ts.URL + "\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create private scaffolds dir (empty) so ReadPrivateScaffolds doesn't fail.
+	if err := os.MkdirAll(filepath.Join(home, ".tentacular", "scaffolds"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a public index entry with path and files.
+	cacheDir := filepath.Join(home, ".tentacular", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	indexContent := `version: "1"
+generated: "2026-01-01"
+scaffolds:
+  - name: web-monitor
+    displayName: Web Monitor
+    description: Probe HTTP endpoints
+    category: monitoring
+    author: test
+    version: "1.0"
+    path: "quickstarts/web-monitor"
+    tags: []
+    files:
+      - "workflow.yaml"
+      - "scaffold.yaml"
+      - "nodes/probe.ts"
+`
+	if err := os.WriteFile(filepath.Join(cacheDir, "scaffolds-index.yaml"), []byte(indexContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "my-tentacle")
+	err := makeScaffoldInitCmd("web-monitor", "my-tentacle",
+		map[string]string{"dir": outDir, "source": "public"},
+		map[string]bool{"no-params": true},
+	)
+	if err != nil {
+		t.Fatalf("scaffold init from public: %v", err)
+	}
+
+	// Verify files were fetched and written.
+	if _, statErr := os.Stat(filepath.Join(outDir, "workflow.yaml")); statErr != nil {
+		t.Errorf("expected workflow.yaml: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(outDir, "nodes", "probe.ts")); statErr != nil {
+		t.Errorf("expected nodes/probe.ts: %v", statErr)
+	}
+
+	// Verify workflow name was renamed to tentacle name.
+	data, readErr := os.ReadFile(filepath.Join(outDir, "workflow.yaml"))
+	if readErr != nil {
+		t.Fatalf("reading workflow.yaml: %v", readErr)
+	}
+	if !strings.Contains(string(data), "name: my-tentacle") {
+		t.Errorf("expected workflow name to be 'my-tentacle', got:\n%s", string(data))
+	}
+
+	// Verify tentacle.yaml records source=public.
+	tentData, tentErr := os.ReadFile(filepath.Join(outDir, "tentacle.yaml"))
+	if tentErr != nil {
+		t.Fatalf("reading tentacle.yaml: %v", tentErr)
+	}
+	if !strings.Contains(string(tentData), "public") {
+		t.Errorf("expected source=public in tentacle.yaml, got:\n%s", string(tentData))
 	}
 }


### PR DESCRIPTION
## Summary

- `tntc scaffold init` for public scaffolds now fetches files on-demand from the remote repo instead of failing with "no local path; run sync first"
- Uses the existing `client.FetchFile()` method (was implemented but never wired into init)
- Private scaffolds with local paths continue to use `copyScaffoldDir()` unchanged
- Fixes v0.7.0 issue B3 (tracked in scratch/v070-release-tracker.md)

## Test plan

- [x] `TestScaffoldInitPublicFetch` — new test with httptest server validates full on-demand fetch flow
- [x] `TestScaffoldInitSourcePublicNoPath` — error case when entry has no path or files
- [x] All 12 existing scaffold init tests pass (no regressions)
- [x] `golangci-lint run ./pkg/cli/...` — 0 issues

Part of v0.7.0 release. See also:
- randybias/tentacular-skill#31 (sidecar hooks docs)
- randybias/tentacular-scaffolds#6 (scaffold bugfixes)
- randybias/tentacular-docs#14 (architecture diagram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)