### PR TITLE
fix(netpol): add OTel collector egress to generated NetworkPolicies

### DIFF
--- a/pkg/k8s/netpol.go
+++ b/pkg/k8s/netpol.go
@@ -65,6 +65,24 @@ func GenerateNetworkPolicy(wf *spec.Workflow, namespace, proxyNamespace string) 
 		}
 		egressBuf.WriteString(proxyEgress)
 	}
+
+	// Always add OTel collector egress — engine pods emit traces to the collector
+	// in tentacular-observability. Without this rule, telemetry is silently dropped.
+	{
+		otelEgress := `  # OTel collector: engine telemetry (OTLP/HTTP on 4318, gRPC on 4317)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: tentacular-observability
+    ports:
+    - protocol: TCP
+      port: 4317
+    - protocol: TCP
+      port: 4318
+`
+		egressBuf.WriteString(otelEgress)
+	}
+
 	egressYAML := egressBuf.String()
 
 	// Build ingress rules YAML from derived rules.


### PR DESCRIPTION
## Summary
- Adds automatic OTel collector egress rules (ports 4317/4318 to `tentacular-observability`) to all generated NetworkPolicies
- The builder already injects OTel env vars into every Deployment, but the NetworkPolicy generator was missing the corresponding egress rules
- This caused workflow pods to silently fail to send traces, which is why spans stopped appearing in ClickHouse after previous manual patches expired

## Test plan
- [x] `go test ./pkg/k8s/ ./pkg/builder/` passes
- [x] Redeployed all 6 otel-* tentacles with the fix — OTel egress rules now present in NetworkPolicies
- [x] Spans flowing to ClickHouse (verified via E2E observability tests)
- [x] All 5 observability E2E tests pass (WorkflowTrace, LLMTelemetry, GracefulDegradation, ErrorSpan, EnrichmentApplied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)