### PR TITLE
feat(metadata): read prompts.yaml and store in Tier 2 ConfigMap

### DIFF
--- a/pkg/builder/metadata.go
+++ b/pkg/builder/metadata.go
@@ -7,7 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/randybias/tentacular/pkg/spec"
 )
@@ -32,6 +35,7 @@ type MetadataBundle struct {
 	Readme          string
 	ContractSummary string
 	ParamsSchema    string
+	Prompts         string
 }
 
 // ReadMetadata reads all metadata files from the tentacle directory
@@ -71,6 +75,21 @@ func ReadMetadata(wf *spec.Workflow, tentacleDir string) *MetadataBundle {
 	paramsPath := filepath.Join(tentacleDir, "params.schema.yaml")
 	if data, err := os.ReadFile(paramsPath); err == nil { //nolint:gosec // reading user-specified files
 		bundle.ParamsSchema = string(data)
+	}
+
+	// --- Tier 2: prompts.yaml ---
+	promptsPath := filepath.Join(tentacleDir, "prompts.yaml")
+	if data, err := os.ReadFile(promptsPath); err == nil { //nolint:gosec // reading user-specified files
+		bundle.Prompts = string(data)
+	}
+	if bundle.Prompts != "" {
+		pc, tc := promptTemplateCounts(bundle.Prompts)
+		if pc > 0 {
+			bundle.Annotations["tentacular.io/prompt-count"] = strconv.Itoa(pc)
+		}
+		if tc > 0 {
+			bundle.Annotations["tentacular.io/template-count"] = strconv.Itoa(tc)
+		}
 	}
 
 	// --- Tier 2: Contract summary ---
@@ -187,6 +206,9 @@ func GenerateMetadataConfigMap(name, namespace string, bundle *MetadataBundle) (
 	if bundle.ParamsSchema != "" {
 		data["params_schema"] = truncateIfNeeded(bundle.ParamsSchema, maxConfigMapKeySize)
 	}
+	if bundle.Prompts != "" {
+		data["prompts"] = truncateIfNeeded(bundle.Prompts, maxConfigMapKeySize)
+	}
 	if bundle.GitProvenance != nil {
 		provJSON, err := json.Marshal(bundle.GitProvenance)
 		if err == nil {
@@ -300,6 +322,18 @@ func generateContractSummary(wf *spec.Workflow) string {
 	}
 
 	return sb.String()
+}
+
+// promptTemplateCounts parses prompts.yaml just enough to count entries.
+func promptTemplateCounts(raw string) (prompts, templates int) {
+	var doc struct {
+		Prompts   []any `yaml:"prompts"`
+		Templates []any `yaml:"templates"`
+	}
+	if err := yaml.Unmarshal([]byte(raw), &doc); err != nil {
+		return 0, 0
+	}
+	return len(doc.Prompts), len(doc.Templates)
 }
 
 // truncateIfNeeded truncates value to maxBytes, appending a [truncated] marker.

--- a/pkg/builder/metadata_test.go
+++ b/pkg/builder/metadata_test.go
@@ -679,6 +679,69 @@ func TestGenerateK8sManifestsMetadataAnnotationsEscaped(t *testing.T) {
 
 // --- Tests: truncateIfNeeded ---
 
+// --- Tests: Prompts support ---
+
+func TestReadMetadataPromptsPresent(t *testing.T) {
+	dir := t.TempDir()
+	content := `version: "1"
+prompts:
+  - node: analyze
+    name: analysis-prompt
+    model: claude-sonnet-4-5
+    system_prompt: "You are an analyst."
+templates:
+  - node: report
+    name: report-template
+    format: markdown
+    template: "# {{title}}"
+`
+	if err := os.WriteFile(filepath.Join(dir, "prompts.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Need a minimal workflow.yaml too
+	if err := os.WriteFile(filepath.Join(dir, "workflow.yaml"), []byte("name: test-wf\nversion: \"1.0.0\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wf := &spec.Workflow{Name: "test-wf", Version: "1.0.0"}
+	bundle := ReadMetadata(wf, dir)
+	if bundle.Prompts == "" {
+		t.Error("expected prompts to be populated")
+	}
+	if bundle.Annotations["tentacular.io/prompt-count"] != "1" {
+		t.Errorf("expected prompt-count=1, got %q", bundle.Annotations["tentacular.io/prompt-count"])
+	}
+	if bundle.Annotations["tentacular.io/template-count"] != "1" {
+		t.Errorf("expected template-count=1, got %q", bundle.Annotations["tentacular.io/template-count"])
+	}
+}
+
+func TestReadMetadataPromptsMissing(t *testing.T) {
+	dir := t.TempDir()
+	wf := &spec.Workflow{Name: "test-wf", Version: "1.0.0"}
+	bundle := ReadMetadata(wf, dir)
+	if bundle.Prompts != "" {
+		t.Errorf("expected empty prompts, got: %q", bundle.Prompts)
+	}
+	if _, ok := bundle.Annotations["tentacular.io/prompt-count"]; ok {
+		t.Error("expected no prompt-count annotation")
+	}
+}
+
+func TestGenerateMetadataConfigMapIncludesPrompts(t *testing.T) {
+	bundle := &MetadataBundle{
+		Annotations: make(map[string]string),
+		Prompts:     "version: \"1\"\nprompts:\n  - node: x\n",
+	}
+	m, err := GenerateMetadataConfigMap("test", "ns", bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The manifest YAML should contain "prompts:" key in the ConfigMap data
+	if !strings.Contains(m.Content, "prompts:") {
+		t.Error("expected ConfigMap to contain prompts key")
+	}
+}
+
 func TestTruncateIfNeededUnderLimit(t *testing.T) {
 	v := "hello world"
 	result := truncateIfNeeded(v, 100)


### PR DESCRIPTION
## Summary
- Builder reads optional `prompts.yaml` from tentacle source directory
- Stores full YAML content in Tier 2 metadata ConfigMap under `prompts` data key
- Adds Tier 1 annotations: `tentacular.io/prompt-count`, `tentacular.io/template-count`
- Uses `promptTemplateCounts()` helper to parse counts without importing full schema

Part of Plan B2 (Tentacle Metadata). Companion PR: randybias/tentacular-mcp#102 (wf_describe enrichment).

## Test plan
- [x] `TestReadMetadataPromptsPresent` — verifies content read and annotations set
- [x] `TestReadMetadataPromptsMissing` — verifies empty when file absent
- [x] `TestGenerateMetadataConfigMapIncludesPrompts` — verifies ConfigMap contains prompts key
- [x] `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)