### PR TITLE
feat: add --quota flag to tntc enclave sync

### DIFF
--- a/pkg/cli/enclave.go
+++ b/pkg/cli/enclave.go
@@ -266,6 +266,7 @@ func newEnclaveSyncCmd() *cobra.Command {
 	cmd.Flags().String("new-owner", "", "Transfer ownership to this email")
 	cmd.Flags().String("channel-name", "", "Update the platform channel name")
 	cmd.Flags().String("status", "", "Set enclave status (active|frozen)")
+	cmd.Flags().String("quota", "", "Update resource quota preset (small|medium|large)")
 	return cmd
 }
 
@@ -278,9 +279,10 @@ func runEnclaveSync(cmd *cobra.Command, args []string) error {
 	newOwner, _ := cmd.Flags().GetString("new-owner")
 	channelName, _ := cmd.Flags().GetString("channel-name")
 	status, _ := cmd.Flags().GetString("status")
+	quota, _ := cmd.Flags().GetString("quota")
 
-	if addRaw == "" && removeRaw == "" && newOwner == "" && channelName == "" && status == "" {
-		return errors.New("at least one of --add-members, --remove-members, --new-owner, --channel-name, or --status must be specified")
+	if addRaw == "" && removeRaw == "" && newOwner == "" && channelName == "" && status == "" && quota == "" {
+		return errors.New("at least one of --add-members, --remove-members, --new-owner, --channel-name, --status, or --quota must be specified")
 	}
 
 	addMembers := splitEmails(addRaw)
@@ -292,12 +294,13 @@ func runEnclaveSync(cmd *cobra.Command, args []string) error {
 	}
 
 	params := mcp.EnclaveSyncParams{
-		Name:          name,
-		AddMembers:    addMembers,
-		RemoveMembers: removeMembers,
-		NewOwner:      newOwner,
-		ChannelName:   channelName,
-		Status:        status,
+		Name:           name,
+		AddMembers:     addMembers,
+		RemoveMembers:  removeMembers,
+		NewOwner:       newOwner,
+		ChannelName:    channelName,
+		Status:         status,
+		NewQuotaPreset: quota,
 	}
 
 	result, err := mcpClient.EnclaveSync(cmd.Context(), params)

--- a/pkg/mcp/tools_enclave.go
+++ b/pkg/mcp/tools_enclave.go
@@ -134,12 +134,13 @@ func (c *Client) EnclaveList(ctx context.Context, callerEmail string) ([]Enclave
 
 // EnclaveSyncParams are the arguments for the enclave_sync MCP tool.
 type EnclaveSyncParams struct {
-	Name          string   `json:"name"`
-	NewOwner      string   `json:"new_owner,omitempty"`
-	ChannelName   string   `json:"new_channel_name,omitempty"`
-	Status        string   `json:"new_status,omitempty"`
-	AddMembers    []string `json:"add_members,omitempty"`
-	RemoveMembers []string `json:"remove_members,omitempty"`
+	Name           string   `json:"name"`
+	NewOwner       string   `json:"new_owner,omitempty"`
+	ChannelName    string   `json:"new_channel_name,omitempty"`
+	Status         string   `json:"new_status,omitempty"`
+	NewQuotaPreset string   `json:"new_quota_preset,omitempty"`
+	AddMembers     []string `json:"add_members,omitempty"`
+	RemoveMembers  []string `json:"remove_members,omitempty"`
 }
 
 // EnclaveSyncResult is the response from enclave_sync.


### PR DESCRIPTION
## Summary
- Add `--quota` flag to `tntc enclave sync` (small|medium|large)
- Wire `NewQuotaPreset` through MCP client params

## Test plan
- [x] All unit tests pass (`go test ./pkg/...`)
- [ ] Verify `tntc enclave sync tentacular-e2e-test --quota large` updates quota

Companion PR: randybias/tentacular-mcp#106

🤖 Generated with [Claude Code](https://claude.com/claude-code)