### PR TITLE
feat: add mandatory node description to workflow spec

### DIFF
--- a/engine/compiler/compiler_test.ts
+++ b/engine/compiler/compiler_test.ts
@@ -7,7 +7,7 @@ function makeSpec(overrides: Partial<WorkflowSpec> = {}): WorkflowSpec {
     name: "test",
     version: "1.0",
     triggers: [{ type: "manual" }],
-    nodes: { a: { path: "./a.ts" } },
+    nodes: { a: { path: "./a.ts", description: "Test node" } },
     edges: [],
     ...overrides,
   };
@@ -24,9 +24,9 @@ Deno.test("compile: linear chain a→b→c", () => {
   const graph = compile(
     makeSpec({
       nodes: {
-        a: { path: "./a.ts" },
-        b: { path: "./b.ts" },
-        c: { path: "./c.ts" },
+        a: { path: "./a.ts", description: "Test node" },
+        b: { path: "./b.ts", description: "Test node" },
+        c: { path: "./c.ts", description: "Test node" },
       },
       edges: [
         { from: "a", to: "b" },
@@ -45,9 +45,9 @@ Deno.test("compile: fan-out a→b, a→c", () => {
   const graph = compile(
     makeSpec({
       nodes: {
-        a: { path: "./a.ts" },
-        b: { path: "./b.ts" },
-        c: { path: "./c.ts" },
+        a: { path: "./a.ts", description: "Test node" },
+        b: { path: "./b.ts", description: "Test node" },
+        c: { path: "./c.ts", description: "Test node" },
       },
       edges: [
         { from: "a", to: "b" },
@@ -66,10 +66,10 @@ Deno.test("compile: fan-in b→d, c→d", () => {
   const graph = compile(
     makeSpec({
       nodes: {
-        a: { path: "./a.ts" },
-        b: { path: "./b.ts" },
-        c: { path: "./c.ts" },
-        d: { path: "./d.ts" },
+        a: { path: "./a.ts", description: "Test node" },
+        b: { path: "./b.ts", description: "Test node" },
+        c: { path: "./c.ts", description: "Test node" },
+        d: { path: "./d.ts", description: "Test node" },
       },
       edges: [
         { from: "a", to: "b" },
@@ -90,10 +90,10 @@ Deno.test("compile: diamond pattern", () => {
   const graph = compile(
     makeSpec({
       nodes: {
-        a: { path: "./a.ts" },
-        b: { path: "./b.ts" },
-        c: { path: "./c.ts" },
-        d: { path: "./d.ts" },
+        a: { path: "./a.ts", description: "Test node" },
+        b: { path: "./b.ts", description: "Test node" },
+        c: { path: "./c.ts", description: "Test node" },
+        d: { path: "./d.ts", description: "Test node" },
       },
       edges: [
         { from: "a", to: "b" },
@@ -115,8 +115,8 @@ Deno.test("compile: cycle throws error", () => {
       compile(
         makeSpec({
           nodes: {
-            a: { path: "./a.ts" },
-            b: { path: "./b.ts" },
+            a: { path: "./a.ts", description: "Test node" },
+            b: { path: "./b.ts", description: "Test node" },
           },
           edges: [
             { from: "a", to: "b" },
@@ -135,9 +135,9 @@ Deno.test("compile: indirect cycle throws error", () => {
       compile(
         makeSpec({
           nodes: {
-            a: { path: "./a.ts" },
-            b: { path: "./b.ts" },
-            c: { path: "./c.ts" },
+            a: { path: "./a.ts", description: "Test node" },
+            b: { path: "./b.ts", description: "Test node" },
+            c: { path: "./c.ts", description: "Test node" },
           },
           edges: [
             { from: "a", to: "b" },
@@ -156,7 +156,7 @@ Deno.test("compile: undefined node in edge throws error", () => {
     () =>
       compile(
         makeSpec({
-          nodes: { a: { path: "./a.ts" } },
+          nodes: { a: { path: "./a.ts", description: "Test node" } },
           edges: [{ from: "a", to: "nonexistent" }],
         }),
       ),
@@ -170,7 +170,7 @@ Deno.test("compile: self-loop throws error", () => {
     () =>
       compile(
         makeSpec({
-          nodes: { a: { path: "./a.ts" } },
+          nodes: { a: { path: "./a.ts", description: "Test node" } },
           edges: [{ from: "a", to: "a" }],
         }),
       ),

--- a/engine/executor/simple_test.ts
+++ b/engine/executor/simple_test.ts
@@ -50,7 +50,10 @@ Deno.test("SimpleExecutor: single node", async () => {
 
 Deno.test("SimpleExecutor: linear chain passes data", async () => {
   const spec = makeSpec(
-    { a: { path: "./a.ts", description: "Test node" }, b: { path: "./b.ts", description: "Test node" } },
+    {
+      a: { path: "./a.ts", description: "Test node" },
+      b: { path: "./b.ts", description: "Test node" },
+    },
     [{ from: "a", to: "b" }],
   );
   const graph = compile(spec);
@@ -70,7 +73,10 @@ Deno.test("SimpleExecutor: linear chain passes data", async () => {
 
 Deno.test("SimpleExecutor: node failure stops execution", async () => {
   const spec = makeSpec(
-    { a: { path: "./a.ts", description: "Test node" }, b: { path: "./b.ts", description: "Test node" } },
+    {
+      a: { path: "./a.ts", description: "Test node" },
+      b: { path: "./b.ts", description: "Test node" },
+    },
     [{ from: "a", to: "b" }],
   );
   const graph = compile(spec);

--- a/engine/executor/simple_test.ts
+++ b/engine/executor/simple_test.ts
@@ -20,7 +20,7 @@ function makeRunner(handlers: Record<string, (input: unknown) => unknown>): Node
 }
 
 function makeSpec(
-  nodes: Record<string, { path: string }>,
+  nodes: Record<string, { path: string; description: string }>,
   edges: { from: string; to: string }[],
 ): WorkflowSpec {
   return {
@@ -33,7 +33,7 @@ function makeSpec(
 }
 
 Deno.test("SimpleExecutor: single node", async () => {
-  const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+  const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
 
@@ -50,7 +50,7 @@ Deno.test("SimpleExecutor: single node", async () => {
 
 Deno.test("SimpleExecutor: linear chain passes data", async () => {
   const spec = makeSpec(
-    { a: { path: "./a.ts" }, b: { path: "./b.ts" } },
+    { a: { path: "./a.ts", description: "Test node" }, b: { path: "./b.ts", description: "Test node" } },
     [{ from: "a", to: "b" }],
   );
   const graph = compile(spec);
@@ -70,7 +70,7 @@ Deno.test("SimpleExecutor: linear chain passes data", async () => {
 
 Deno.test("SimpleExecutor: node failure stops execution", async () => {
   const spec = makeSpec(
-    { a: { path: "./a.ts" }, b: { path: "./b.ts" } },
+    { a: { path: "./a.ts", description: "Test node" }, b: { path: "./b.ts", description: "Test node" } },
     [{ from: "a", to: "b" }],
   );
   const graph = compile(spec);
@@ -94,9 +94,9 @@ Deno.test("SimpleExecutor: node failure stops execution", async () => {
 Deno.test("SimpleExecutor: parallel nodes in same stage", async () => {
   const spec = makeSpec(
     {
-      a: { path: "./a.ts" },
-      b: { path: "./b.ts" },
-      c: { path: "./c.ts" },
+      a: { path: "./a.ts", description: "Test node" },
+      b: { path: "./b.ts", description: "Test node" },
+      c: { path: "./c.ts", description: "Test node" },
     },
     [
       { from: "a", to: "b" },
@@ -125,7 +125,7 @@ Deno.test("SimpleExecutor: parallel nodes in same stage", async () => {
 });
 
 Deno.test("SimpleExecutor: retry with exponential backoff", async () => {
-  const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+  const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
 
@@ -147,7 +147,7 @@ Deno.test("SimpleExecutor: retry with exponential backoff", async () => {
 });
 
 Deno.test("SimpleExecutor: retry exhausted returns failure", async () => {
-  const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+  const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
 
@@ -172,7 +172,7 @@ Deno.test({
   sanitizeOps: false,
   sanitizeResources: false,
   fn: async () => {
-    const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+    const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
     const graph = compile(spec);
     const ctx = createMockContext();
 

--- a/engine/loader.ts
+++ b/engine/loader.ts
@@ -50,7 +50,7 @@ export function clearModuleCache(): void {
  * Returns a map of nodeId → NodeFunction.
  */
 export async function loadAllNodes(
-  nodes: Record<string, { path: string }>,
+  nodes: Record<string, { path: string; [key: string]: unknown }>,
   workflowDir: string,
   bustCache = false,
 ): Promise<Map<string, NodeFunction>> {

--- a/engine/server_test.ts
+++ b/engine/server_test.ts
@@ -11,7 +11,7 @@ function makeSpec(): WorkflowSpec {
     name: "test",
     version: "1.0",
     triggers: [{ type: "manual" }],
-    nodes: { a: { path: "./a.ts" } },
+    nodes: { a: { path: "./a.ts", description: "Test node" } },
     edges: [],
   };
 }

--- a/engine/telemetry_test.ts
+++ b/engine/telemetry_test.ts
@@ -233,7 +233,7 @@ Deno.test("NewTelemetrySink: unknown kind defaults to BasicSink", () => {
 // --- SimpleExecutor telemetry integration ---
 
 function makeSpec(
-  nodes: Record<string, { path: string }>,
+  nodes: Record<string, { path: string; description: string }>,
   edges: { from: string; to: string }[],
 ): WorkflowSpec {
   return {
@@ -246,7 +246,7 @@ function makeSpec(
 }
 
 Deno.test("SimpleExecutor: records node-start and node-complete on success", async () => {
-  const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+  const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
   const sink = new BasicSink();
@@ -269,7 +269,7 @@ Deno.test("SimpleExecutor: records node-start and node-complete on success", asy
 });
 
 Deno.test("SimpleExecutor: records node-start and node-error on failure", async () => {
-  const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+  const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
   const sink = new BasicSink();
@@ -293,7 +293,7 @@ Deno.test("SimpleExecutor: records node-start and node-error on failure", async 
 });
 
 Deno.test("SimpleExecutor: node events include node name in metadata", async () => {
-  const spec = makeSpec({ mynode: { path: "./mynode.ts" } }, []);
+  const spec = makeSpec({ mynode: { path: "./mynode.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
   const sink = new BasicSink();
@@ -315,7 +315,7 @@ Deno.test("SimpleExecutor: node events include node name in metadata", async () 
 
 Deno.test("SimpleExecutor: records events for multiple nodes across stages", async () => {
   const spec = makeSpec(
-    { a: { path: "./a.ts" }, b: { path: "./b.ts" } },
+    { a: { path: "./a.ts", description: "Test node" }, b: { path: "./b.ts", description: "Test node" } },
     [{ from: "a", to: "b" }],
   );
   const graph = compile(spec);
@@ -337,7 +337,7 @@ Deno.test("SimpleExecutor: records events for multiple nodes across stages", asy
 });
 
 Deno.test("SimpleExecutor: uptimeMs is non-negative after execution", async () => {
-  const spec = makeSpec({ a: { path: "./a.ts" } }, []);
+  const spec = makeSpec({ a: { path: "./a.ts", description: "Test node" } }, []);
   const graph = compile(spec);
   const ctx = createMockContext();
   const sink = new BasicSink();

--- a/engine/telemetry_test.ts
+++ b/engine/telemetry_test.ts
@@ -315,7 +315,10 @@ Deno.test("SimpleExecutor: node events include node name in metadata", async () 
 
 Deno.test("SimpleExecutor: records events for multiple nodes across stages", async () => {
   const spec = makeSpec(
-    { a: { path: "./a.ts", description: "Test node" }, b: { path: "./b.ts", description: "Test node" } },
+    {
+      a: { path: "./a.ts", description: "Test node" },
+      b: { path: "./b.ts", description: "Test node" },
+    },
     [{ from: "a", to: "b" }],
   );
   const graph = compile(spec);

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -64,6 +64,7 @@ export interface Trigger {
 
 export interface NodeSpec {
   path: string;
+  description: string;
   capabilities?: Record<string, string>;
 }
 

--- a/pkg/builder/k8s_annotations_test.go
+++ b/pkg/builder/k8s_annotations_test.go
@@ -221,6 +221,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 metadata:
   group: platform-team
@@ -255,6 +256,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 metadata:
   owner: old-owner
@@ -288,6 +290,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 `
 	wf, errs := spec.Parse([]byte(yamlContent))
@@ -308,6 +311,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 metadata:
   group: team-a

--- a/pkg/builder/k8s_test.go
+++ b/pkg/builder/k8s_test.go
@@ -482,6 +482,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "workflow.yaml"), []byte(workflowContent), 0o644); err != nil {
 		t.Fatal(err)

--- a/pkg/builder/metadata.go
+++ b/pkg/builder/metadata.go
@@ -30,12 +30,13 @@ type GitProvenance struct {
 
 // MetadataBundle holds all metadata extracted from the tentacle directory.
 type MetadataBundle struct {
-	Annotations     map[string]string
-	GitProvenance   *GitProvenance
-	Readme          string
-	ContractSummary string
-	ParamsSchema    string
-	Prompts         string
+	Annotations      map[string]string
+	GitProvenance    *GitProvenance
+	Readme           string
+	ContractSummary  string
+	ParamsSchema     string
+	Prompts          string
+	NodeDescriptions string
 }
 
 // ReadMetadata reads all metadata files from the tentacle directory
@@ -48,6 +49,9 @@ func ReadMetadata(wf *spec.Workflow, tentacleDir string) *MetadataBundle {
 
 	// --- Tier 1: Structural metadata from workflow spec ---
 	buildTier1Annotations(bundle, wf)
+
+	// --- Tier 1: Node descriptions for ConfigMap and MCP tools ---
+	bundle.NodeDescriptions = nodeDescriptions(wf.Nodes)
 
 	// --- Tier 1: Version from git + workflow.yaml ---
 	version := deriveVersion(wf.Version, tentacleDir)
@@ -215,6 +219,12 @@ func GenerateMetadataConfigMap(name, namespace string, bundle *MetadataBundle) (
 			data["git_provenance"] = string(provJSON)
 		}
 	}
+	// node_descriptions: JSON array of [{name, description}] for each workflow node.
+	// Read by tentacular-mcp/pkg/tools/discover.go (wf_describe) and validated by
+	// tentacular-mcp/pkg/tools/deploy.go (wf_apply). Format: [{"name":"x","description":"y"}]
+	if bundle.NodeDescriptions != "" {
+		data["node_descriptions"] = bundle.NodeDescriptions
+	}
 
 	if len(data) == 0 {
 		return Manifest{}, nil // no metadata to store
@@ -334,6 +344,29 @@ func promptTemplateCounts(raw string) (prompts, templates int) {
 		return 0, 0
 	}
 	return len(doc.Prompts), len(doc.Templates)
+}
+
+// nodeDescriptions builds a sorted JSON array of {name, description} for all nodes.
+// Returns empty string if nodes is empty or marshaling fails.
+func nodeDescriptions(nodes map[string]spec.NodeSpec) string {
+	type nodeMeta struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	names := make([]string, 0, len(nodes))
+	for name := range nodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	entries := make([]nodeMeta, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, nodeMeta{Name: name, Description: nodes[name].Description})
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // truncateIfNeeded truncates value to maxBytes, appending a [truncated] marker.

--- a/pkg/builder/metadata_test.go
+++ b/pkg/builder/metadata_test.go
@@ -541,6 +541,25 @@ func TestGenerateMetadataConfigMapAllKeys(t *testing.T) {
 	}
 }
 
+// TestGenerateMetadataConfigMapIncludesNodeDescriptions verifies that the
+// node_descriptions key is written to the ConfigMap when nodes have descriptions.
+func TestGenerateMetadataConfigMapIncludesNodeDescriptions(t *testing.T) {
+	bundle := &MetadataBundle{
+		Annotations:      make(map[string]string),
+		NodeDescriptions: `[{"name":"analyze","description":"Runs LLM analysis"},{"name":"fetch","description":"Fetches data"}]`,
+	}
+	m, err := GenerateMetadataConfigMap("test-wf", "ns", bundle)
+	if err != nil {
+		t.Fatalf("GenerateMetadataConfigMap failed: %v", err)
+	}
+	if !strings.Contains(m.Content, "node_descriptions:") {
+		t.Error("expected ConfigMap to contain node_descriptions key")
+	}
+	if !strings.Contains(m.Content, "Runs LLM analysis") {
+		t.Error("expected node_descriptions to contain node description text")
+	}
+}
+
 func TestGenerateMetadataConfigMapEmptyBundle(t *testing.T) {
 	bundle := &MetadataBundle{}
 	cm, err := GenerateMetadataConfigMap("empty-wf", "ns", bundle)

--- a/pkg/cli/build_test.go
+++ b/pkg/cli/build_test.go
@@ -152,6 +152,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 `), 0o644)
 
 	cmd := NewBuildCmd()

--- a/pkg/cli/scaffold_params_test.go
+++ b/pkg/cli/scaffold_params_test.go
@@ -61,6 +61,7 @@ config:
 nodes:
   probe:
     path: ./nodes/probe.ts
+    description: "Test node"
 `
 
 const paramsTestWorkflowExampleYAML = `name: my-tentacle
@@ -77,6 +78,7 @@ config:
 nodes:
   probe:
     path: ./nodes/probe.ts
+    description: "Test node"
 `
 
 const paramsTestSchemaYAML = `version: "1"

--- a/pkg/cli/secrets_test.go
+++ b/pkg/cli/secrets_test.go
@@ -383,6 +383,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:
@@ -429,6 +430,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:
@@ -458,6 +460,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 `
 	required, err := scanContractSecrets([]byte(yamlContent))
 	if err != nil {
@@ -489,6 +492,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:

--- a/pkg/cli/validate_integration_test.go
+++ b/pkg/cli/validate_integration_test.go
@@ -27,6 +27,7 @@ triggers:
 nodes:
   handler:
     path: ./handler.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies: {}
@@ -80,6 +81,7 @@ triggers:
 nodes:
   handler:
     path: ./handler.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:
@@ -152,6 +154,7 @@ triggers:
 nodes:
   handler:
     path: ./handler.ts
+    description: "Test node"
 `
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "workflow.yaml")

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -29,6 +29,7 @@ triggers:
 nodes:
   handler:
     path: ./handler.ts
+    description: "Test node"
 `
 
 // contractWorkflowYAML includes a contract section with two dependencies.
@@ -47,8 +48,10 @@ triggers:
 nodes:
   fetch:
     path: ./fetch.ts
+    description: "Test node"
   store:
     path: ./store.ts
+    description: "Test node"
 edges:
   - from: fetch
     to: store

--- a/pkg/k8s/e2e_security_test.go
+++ b/pkg/k8s/e2e_security_test.go
@@ -22,12 +22,16 @@ triggers:
 nodes:
   fetch-feeds:
     path: ./nodes/fetch-feeds.ts
+    description: "Test node"
   filter-24h:
     path: ./nodes/filter-24h.ts
+    description: "Test node"
   summarize-llm:
     path: ./nodes/summarize-llm.ts
+    description: "Test node"
   notify-slack:
     path: ./nodes/notify-slack.ts
+    description: "Test node"
 
 edges:
   - from: fetch-feeds
@@ -216,10 +220,13 @@ triggers:
 nodes:
   fetch-repos:
     path: ./nodes/fetch-repos.ts
+    description: "Test node"
   summarize:
     path: ./nodes/summarize.ts
+    description: "Test node"
   notify:
     path: ./nodes/notify.ts
+    description: "Test node"
 
 edges:
   - from: fetch-repos
@@ -312,6 +319,7 @@ triggers:
 nodes:
   count:
     path: ./nodes/count.ts
+    description: "Test node"
 
 edges: []
 `
@@ -354,8 +362,10 @@ triggers:
 nodes:
   handle:
     path: ./nodes/handle.ts
+    description: "Test node"
   process:
     path: ./nodes/process.ts
+    description: "Test node"
 
 edges:
   - from: handle

--- a/pkg/k8s/netpol_test.go
+++ b/pkg/k8s/netpol_test.go
@@ -589,8 +589,10 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
   process:
     path: ./nodes/process.ts
+    description: "Test node"
 
 edges:
   - from: fetch

--- a/pkg/params/overlay_test.go
+++ b/pkg/params/overlay_test.go
@@ -32,6 +32,7 @@ config:
 nodes:
   probe-endpoints:
     path: ./nodes/probe-endpoints.ts
+    description: "Test node"
 `
 
 // parseReferenceDoc parses referenceWorkflowYAML and returns the root mapping node.

--- a/pkg/spec/contract_test.go
+++ b/pkg/spec/contract_test.go
@@ -16,6 +16,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -42,6 +43,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -111,6 +113,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -146,6 +149,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -181,6 +185,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -232,6 +237,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -281,6 +287,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -313,6 +320,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -345,6 +353,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -378,6 +387,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -411,6 +421,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -443,6 +454,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -478,6 +490,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -520,6 +533,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -556,6 +570,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:
@@ -578,6 +593,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -595,6 +611,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -612,6 +629,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -647,6 +665,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -665,6 +684,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -683,6 +703,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -701,6 +722,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -741,6 +763,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -770,6 +793,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -803,6 +827,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:
@@ -840,6 +865,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -866,6 +892,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 contract:
   version: "1"
   networkPolicy:
@@ -907,6 +934,7 @@ triggers:
 nodes:
   check:
     path: ./check.ts
+    description: "Test node"
 contract:
   version: "1"
   dependencies:

--- a/pkg/spec/module_proxy_test.go
+++ b/pkg/spec/module_proxy_test.go
@@ -15,6 +15,7 @@ triggers:
 nodes:
   step1:
     path: nodes/step1.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -62,6 +63,7 @@ triggers:
 nodes:
   step1:
     path: nodes/step1.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"

--- a/pkg/spec/parse.go
+++ b/pkg/spec/parse.go
@@ -103,6 +103,9 @@ func Parse(data []byte) (*Workflow, []string) {
 		if node.Path == "" {
 			errs = append(errs, fmt.Sprintf("node %q: path is required", name))
 		}
+		if node.Description == "" {
+			errs = append(errs, fmt.Sprintf("node %q: description is required", name))
+		}
 	}
 
 	// Edges — reference integrity

--- a/pkg/spec/parse_test.go
+++ b/pkg/spec/parse_test.go
@@ -14,8 +14,10 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
   transform:
     path: ./nodes/transform.ts
+    description: "Test node"
 edges:
   - from: fetch
     to: transform
@@ -37,6 +39,32 @@ config:
 	}
 }
 
+func TestParseNodeMissingDescription(t *testing.T) {
+	yaml := `
+name: test-wf
+version: "1.0"
+triggers:
+  - type: manual
+nodes:
+  fetch:
+    path: ./nodes/fetch.ts
+edges: []
+`
+	_, errs := Parse([]byte(yaml))
+	if len(errs) == 0 {
+		t.Fatal("expected error for node missing description")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "description is required") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'description is required' error, got: %v", errs)
+	}
+}
+
 func TestParseMissingName(t *testing.T) {
 	yaml := `
 version: "1.0"
@@ -45,6 +73,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 `
 	_, errs := Parse([]byte(yaml))
@@ -71,6 +100,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 `
 	_, errs := Parse([]byte(yaml))
@@ -88,10 +118,13 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
   b:
     path: ./b.ts
+    description: "Test node"
   c:
     path: ./c.ts
+    description: "Test node"
 edges:
   - from: a
     to: b
@@ -124,6 +157,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges:
   - from: a
     to: nonexistent
@@ -143,6 +177,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 config:
   timeout: 30s
@@ -236,6 +271,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 `
 	wf, errs := Parse([]byte(yaml))
@@ -264,6 +300,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 `
 	_, errs := Parse([]byte(yaml))
@@ -292,6 +329,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 `
 	_, errs := Parse([]byte(yaml))
@@ -319,6 +357,7 @@ triggers:
 nodes:
   handler:
     path: ./nodes/handler.ts
+    description: "Test node"
 edges: []
 `
 	wf, errs := Parse([]byte(yaml))
@@ -342,6 +381,7 @@ triggers:
 nodes:
   handler:
     path: ./nodes/handler.ts
+    description: "Test node"
 edges: []
 `
 	_, errs := Parse([]byte(yaml))
@@ -368,6 +408,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 `
 	_, errs := Parse([]byte(yaml))
@@ -385,6 +426,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 deployment:
   namespace: pd-custom-ns
@@ -407,6 +449,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 `
 	wf, errs := Parse([]byte(yaml))
@@ -427,6 +470,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -473,6 +517,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -515,6 +560,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -546,6 +592,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   dependencies:
@@ -579,6 +626,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   dependencies:
@@ -618,6 +666,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 `
 	wf, errs := Parse([]byte(yaml))
@@ -639,6 +688,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -673,6 +723,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -704,6 +755,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -765,6 +817,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -801,6 +854,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -835,6 +889,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -901,6 +956,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -942,6 +998,7 @@ triggers:
 nodes:
   a:
     path: ./a.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -1099,6 +1156,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 edges: []
 contract:
   version: "1"
@@ -1128,6 +1186,7 @@ triggers:
 nodes:
   fetch:
     path: ./nodes/fetch.ts
+    description: "Test node"
 ` + extra
 }
 

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -41,6 +41,7 @@ type Trigger struct {
 
 type NodeSpec struct {
 	Capabilities map[string]string `yaml:"capabilities,omitempty"`
+	Description  string            `yaml:"description"`
 	Path         string            `yaml:"path"`
 }
 


### PR DESCRIPTION
## Summary
- Adds required `description` field to `NodeSpec` in workflow.yaml
- `spec.Parse()` rejects workflows with missing node descriptions
- Builder extracts descriptions into `node_descriptions` metadata ConfigMap key
- Engine TypeScript types updated to match

## Test plan
- [x] `go test ./pkg/...` passes
- [x] `golangci-lint run ./...` clean
- [x] New test: `TestParseNodeMissingDescription`
- [x] New test: `TestGenerateMetadataConfigMapIncludesNodeDescriptions`
- [x] All existing test fixtures updated with description fields

Part of the v0.9.0-rc.13 release. See also randybias/tentacular-mcp#111

🤖 Generated with [Claude Code](https://claude.com/claude-code)