### PR TITLE
fix: rename remaining --env/environment references to --cluster

### DIFF
--- a/pkg/cli/cmd_whoami.go
+++ b/pkg/cli/cmd_whoami.go
@@ -21,15 +21,15 @@ func NewWhoamiCmd() *cobra.Command {
 
 // whoamiResult is the structured output for JSON mode.
 type whoamiResult struct {
-	Email       string   `json:"email"`
-	Name        string   `json:"name,omitempty"`
-	Subject     string   `json:"subject"`
-	Issuer      string   `json:"issuer,omitempty"`
-	Provider    string   `json:"provider,omitempty"`
-	Environment string   `json:"environment"`
-	ExpiresAt   string   `json:"expires_at,omitempty"`
-	Groups      []string `json:"groups,omitempty"`
-	Expired     bool     `json:"expired"`
+	Email     string   `json:"email"`
+	Name      string   `json:"name,omitempty"`
+	Subject   string   `json:"subject"`
+	Issuer    string   `json:"issuer,omitempty"`
+	Provider  string   `json:"provider,omitempty"`
+	Cluster   string   `json:"cluster"`
+	ExpiresAt string   `json:"expires_at,omitempty"`
+	Groups    []string `json:"groups,omitempty"`
+	Expired   bool     `json:"expired"`
 }
 
 func runWhoami(cmd *cobra.Command, args []string) error {
@@ -52,7 +52,7 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("reading tokens: %w", err)
 	}
 	if store == nil {
-		return fmt.Errorf("not authenticated for environment %q; run 'tntc login -e %s'", clusterName, clusterName)
+		return fmt.Errorf("not authenticated for cluster %q; run 'tntc login -c %s'", clusterName, clusterName)
 	}
 
 	// Decode claims from access token for fresh info
@@ -61,9 +61,9 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 		// Fall back to stored email
 		if outputFormat == "json" {
 			result := whoamiResult{
-				Email:       store.Email,
-				Environment: clusterName,
-				Expired:     store.IsExpired(),
+				Email:   store.Email,
+				Cluster: clusterName,
+				Expired: store.IsExpired(),
 			}
 			if !store.IsExpired() {
 				result.ExpiresAt = store.ExpiresAt.Format(time.RFC3339)
@@ -71,7 +71,7 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 			return emitWhoamiJSON(cmd, result)
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Email:       %s\n", store.Email)
-		fmt.Fprintf(cmd.OutOrStdout(), "Environment: %s\n", clusterName)
+		fmt.Fprintf(cmd.OutOrStdout(), "Cluster: %s\n", clusterName)
 		if store.IsExpired() {
 			fmt.Fprintln(cmd.OutOrStdout(), "Token:       EXPIRED")
 		} else {
@@ -100,15 +100,15 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 
 	if outputFormat == "json" {
 		result := whoamiResult{
-			Email:       email,
-			Name:        name,
-			Subject:     claims.Sub,
-			Issuer:      issuer,
-			Provider:    provider,
-			Environment: clusterName,
-			Expired:     expired,
-			ExpiresAt:   expiresAt,
-			Groups:      claims.Groups,
+			Email:     email,
+			Name:      name,
+			Subject:   claims.Sub,
+			Issuer:    issuer,
+			Provider:  provider,
+			Cluster:   clusterName,
+			Expired:   expired,
+			ExpiresAt: expiresAt,
+			Groups:    claims.Groups,
 		}
 		return emitWhoamiJSON(cmd, result)
 	}
@@ -135,7 +135,7 @@ func runWhoami(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Fprintln(out)
 	}
-	fmt.Fprintf(out, "Environment: %s\n", clusterName)
+	fmt.Fprintf(out, "Cluster: %s\n", clusterName)
 
 	if expired {
 		fmt.Fprintln(out, "Token:       EXPIRED (run 'tntc login' to re-authenticate)")

--- a/pkg/cli/cmd_whoami_test.go
+++ b/pkg/cli/cmd_whoami_test.go
@@ -78,13 +78,13 @@ func TestWhoami_TextOutput_AllFields(t *testing.T) {
 	output := out.String()
 
 	checks := map[string]string{
-		"Email":       "alice@example.com",
-		"Name":        "Alice Smith",
-		"Subject":     "user-123",
-		"Issuer":      "https://auth.example.com/realms/test",
-		"Provider":    "google",
-		"Environment": "default",
-		"Expires":     "", // just check it's present
+		"Email":    "alice@example.com",
+		"Name":     "Alice Smith",
+		"Subject":  "user-123",
+		"Issuer":   "https://auth.example.com/realms/test",
+		"Provider": "google",
+		"Cluster":  "default",
+		"Expires":  "", // just check it's present
 	}
 
 	for label, value := range checks {
@@ -151,8 +151,8 @@ func TestWhoami_JSONOutput(t *testing.T) {
 	if result.Provider != "github" {
 		t.Errorf("expected provider=github, got %q", result.Provider)
 	}
-	if result.Environment != "default" {
-		t.Errorf("expected environment=default, got %q", result.Environment)
+	if result.Cluster != "default" {
+		t.Errorf("expected environment=default, got %q", result.Cluster)
 	}
 	if result.Expired {
 		t.Error("expected expired=false")

--- a/pkg/cli/configure.go
+++ b/pkg/cli/configure.go
@@ -19,22 +19,22 @@ func NewConfigureCmd() *cobra.Command {
 		Short: "Set default configuration",
 		Long: `Set default configuration values for tntc.
 
-Without --env, sets top-level defaults (registry, namespace, runtime-class).
-With --env, creates or updates an environment with OIDC, MCP, and Kubernetes settings.
+Without --cluster, sets top-level defaults (registry, namespace, runtime-class).
+With --cluster, creates or updates a cluster with OIDC, MCP, and Kubernetes settings.
 
 Examples:
   # Set top-level defaults
   tntc configure --registry ghcr.io/myorg --default-namespace myapp
 
-  # Configure an environment with OIDC SSO
-  tntc configure -e staging --oidc-issuer https://auth.example.com/realms/dev \
+  # Configure a cluster with OIDC SSO
+  tntc configure -c staging --oidc-issuer https://auth.example.com/realms/dev \
     --oidc-client-id myclient --mcp-endpoint https://mcp.example.com
 
   # Interactive SSO setup
-  tntc configure --sso -e staging
+  tntc configure --sso -c staging
 
-  # Set the default environment
-  tntc configure --default-env staging`,
+  # Set the default cluster
+  tntc configure --default-cluster staging`,
 		RunE: runConfigure,
 	}
 
@@ -42,10 +42,10 @@ Examples:
 	cmd.Flags().String("registry", "", "Default container registry URL")
 	cmd.Flags().String("default-namespace", "", "Default Kubernetes namespace")
 	cmd.Flags().String("runtime-class", "", "Default RuntimeClass name")
-	cmd.Flags().String("default-env", "", "Set the default environment name")
+	cmd.Flags().String("default-cluster", "", "Set the default cluster name")
 	cmd.Flags().Bool("project", false, "Write to project config (.tentacular/config.yaml) instead of user config")
 
-	// Environment-scoped flags (require --env)
+	// Cluster-scoped flags (require --cluster)
 	cmd.Flags().String("oidc-issuer", "", "OIDC issuer URL (e.g. Keycloak realm URL)")
 	cmd.Flags().String("oidc-client-id", "", "OIDC client ID")
 	cmd.Flags().String("oidc-client-secret", "", "OIDC client secret")
@@ -106,8 +106,8 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("runtime-class") {
 		cfg.RuntimeClass, _ = cmd.Flags().GetString("runtime-class")
 	}
-	if cmd.Flags().Changed("default-env") {
-		cfg.DefaultCluster, _ = cmd.Flags().GetString("default-env")
+	if cmd.Flags().Changed("default-cluster") {
+		cfg.DefaultCluster, _ = cmd.Flags().GetString("default-cluster")
 	}
 
 	// Environment-scoped configuration
@@ -206,7 +206,7 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 
 		// Hint for next step if OIDC was configured
 		if env.OIDCIssuer != "" && env.OIDCClientID != "" {
-			fmt.Fprintf(cmd.OutOrStdout(), "\nNext step: run 'tntc login -e %s' to authenticate.\n", clusterName)
+			fmt.Fprintf(cmd.OutOrStdout(), "\nNext step: run 'tntc login -c %s' to authenticate.\n", clusterName)
 		}
 	}
 

--- a/pkg/cli/configure_test.go
+++ b/pkg/cli/configure_test.go
@@ -194,7 +194,7 @@ func TestConfigure_DefaultEnv(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
-	_ = cmd.Flags().Set("default-env", "staging")
+	_ = cmd.Flags().Set("default-cluster", "staging")
 
 	if err := cmd.RunE(cmd, nil); err != nil {
 		t.Fatalf("runConfigure: %v", err)


### PR DESCRIPTION
## Summary
- `--default-env` flag -> `--default-cluster`
- Configure help text/examples: `--env` -> `--cluster`
- whoami output: "Environment" -> "Cluster"
- Error messages: `login -e` -> `login -c`

Missed during the enclave paradigm pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)