### PR TITLE
fix: tntc test --live reads wrong flag (--env instead of --cluster)

### DIFF
--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -91,7 +91,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// Apply config defaults: workflow.yaml > env config > config file
 	cfg := LoadConfig()
 
-	// Resolve --env: environment config provides namespace, runtime-class defaults.
+	// Resolve --cluster: cluster config provides namespace, runtime-class defaults.
 	if clusterName != "" {
 		env, envErr := cfg.LoadEnvironment(clusterName)
 		if envErr != nil {

--- a/pkg/cli/resolve.go
+++ b/pkg/cli/resolve.go
@@ -24,7 +24,7 @@ func flagString(cmd *cobra.Command, name string) string {
 
 // resolveNamespace determines the target namespace using the cascade:
 // 1. deployment.namespace from workflow.yaml (when workflowDir is provided)
-// 2. env config namespace (from --env or default environment)
+// 2. cluster config namespace (from --cluster or default_cluster)
 // 3. global config namespace
 // 4. "default"
 func resolveNamespace(cmd *cobra.Command, workflowDir string) string {

--- a/pkg/cli/test_live.go
+++ b/pkg/cli/test_live.go
@@ -31,20 +31,20 @@ func runLiveTest(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no workflow.yaml found in %s", absDir)
 	}
 
-	envName := flagString(cmd, "env")
+	clusterName := flagString(cmd, "cluster")
 	keep, _ := cmd.Flags().GetBool("keep")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 
-	// Load environment configuration
-	env, err := ResolveEnvironment(envName)
+	// Load cluster configuration
+	env, err := ResolveEnvironment(clusterName)
 	if err != nil {
-		return fmt.Errorf("loading environment %q: %w", envName, err)
+		return fmt.Errorf("loading cluster %q: %w", clusterName, err)
 	}
 
 	// Determine status output writer (stderr when -o json)
 	w := StatusWriter(cmd)
 
-	_, _ = fmt.Fprintf(w, "Live test: environment=%s, namespace=%s\n", envName, env.Namespace)
+	_, _ = fmt.Fprintf(w, "Live test: cluster=%s, enclave=%s\n", clusterName, env.Namespace)
 
 	// Resolve MCP client
 	mcpClient, err := requireMCPClient(cmd)


### PR DESCRIPTION
Bug: test_live.go was reading flagString(cmd, "env") but the root command registers --cluster. Live tests would never pick up the cluster config.