### PR TITLE
feat(deploy): auto-push git-state commits with SHA annotations

### DIFF
--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -36,6 +36,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().Bool("verify", false, "Run workflow once after deploy to verify")
 	cmd.Flags().Bool("warn", false, "Audit mode: contract violations produce warnings instead of failures")
 	cmd.Flags().String("enclave", "", "Target enclave name (resolves to enclave namespace)")
+	cmd.Flags().Bool("no-push", false, "Skip git push step (emergency bypass; cluster state will diverge from git)")
 	return cmd
 }
 
@@ -46,7 +47,8 @@ type InternalDeployOptions struct {
 	Image           string
 	RuntimeClass    string
 	ImagePullPolicy string
-	Context         string // kubeconfig context override (bootstrap-only)
+	Context         string  // kubeconfig context override (bootstrap-only)
+	GitMeta         GitMeta // optional git provenance; non-empty fields are injected as annotations on the Deployment
 }
 
 // DeployResult holds the result of a deployment.
@@ -138,11 +140,34 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	noPush, _ := cmd.Flags().GetBool("no-push")
+
 	// Git-state deploy gate: if git-state is enabled, verify the repo is clean
-	// for this enclave/tentacle before proceeding.
+	// for this enclave/tentacle before proceeding, then push HEAD to remote and
+	// capture provenance metadata for Deployment annotations.
+	var gitMeta GitMeta
 	if cfg.GitState.Enabled && cfg.GitState.RepoPath != "" {
 		if gitErr := checkGitStateClean(cfg.GitState.RepoPath, enclaveName, wf.Name); gitErr != nil {
 			return emitDeployResult(cmd, "fail", gitErr.Error(), nil, startedAt)
+		}
+
+		branch, branchErr := getCurrentBranch(cfg.GitState.RepoPath)
+		if branchErr != nil {
+			return emitDeployResult(cmd, "fail", "reading git branch: "+branchErr.Error(), nil, startedAt)
+		}
+
+		if noPush {
+			_, _ = fmt.Fprintln(StatusWriter(cmd), "WARNING: --no-push bypasses remote sync; cluster state will diverge from git")
+		} else {
+			if pushErr := pushGitState(cfg.GitState.RepoPath, branch); pushErr != nil {
+				return emitDeployResult(cmd, "fail", "git push failed — deploy aborted: "+pushErr.Error(), nil, startedAt)
+			}
+		}
+
+		var metaErr error
+		gitMeta, metaErr = captureGitMeta(cfg.GitState.RepoPath)
+		if metaErr != nil {
+			return emitDeployResult(cmd, "fail", "reading git metadata: "+metaErr.Error(), nil, startedAt)
 		}
 	}
 
@@ -225,6 +250,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		Image:        imageTag,
 		RuntimeClass: runtimeClass,
 		StatusOut:    w,
+		GitMeta:      gitMeta,
 	}
 
 	deployResult, err := deployWorkflow(absDir, deployOpts, mcpClient)
@@ -430,6 +456,11 @@ func deployWorkflow(workflowDir string, opts InternalDeployOptions, mcpClient *m
 			return nil, fmt.Errorf("serializing manifest %s/%s: %w", m.Kind, m.Name, unmarshalErr)
 		}
 		mcpManifests = append(mcpManifests, obj)
+	}
+
+	// Inject git provenance annotations into the Deployment manifest (if any git metadata present).
+	if opts.GitMeta.SHA != "" {
+		injectGitAnnotations(mcpManifests, opts.GitMeta)
 	}
 
 	// Phase 3: Apply via MCP

--- a/pkg/cli/deploy_gitstate.go
+++ b/pkg/cli/deploy_gitstate.go
@@ -36,3 +36,168 @@ func checkGitStateClean(repoPath, enclaveName, tentacleName string) error {
 	}
 	return nil
 }
+
+// GitMeta holds git provenance metadata captured before a deploy.
+type GitMeta struct {
+	SHA    string // HEAD commit SHA (full)
+	Repo   string // remote URL (origin)
+	Branch string // current branch name
+}
+
+// getCurrentGitSHA returns the full HEAD commit SHA for the given repo.
+func getCurrentGitSHA(repoPath string) (string, error) {
+	cmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "rev-parse", "HEAD") //nolint:gosec // repoPath is config-controlled
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("reading git HEAD SHA: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// getCurrentBranch returns the name of the currently checked-out branch.
+// Returns "HEAD" (detached HEAD state) if no branch name is available.
+func getCurrentBranch(repoPath string) (string, error) {
+	cmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD") //nolint:gosec // repoPath is config-controlled
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("reading current branch: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// getGitRemoteURL returns the fetch URL of the given remote (typically "origin").
+// Returns an empty string if the remote is not configured or the command fails.
+func getGitRemoteURL(repoPath, remote string) string {
+	cmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "remote", "get-url", remote) //nolint:gosec // repoPath is config-controlled
+	out, err := cmd.Output()
+	if err != nil {
+		// Remote may not be configured — return empty string silently.
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// captureGitMeta reads HEAD SHA, branch name, and origin URL from repoPath.
+// Non-fatal: if any piece is unavailable (e.g. detached HEAD, no remote) the
+// corresponding field is set to an empty string and no error is returned.
+func captureGitMeta(repoPath string) (GitMeta, error) {
+	sha, err := getCurrentGitSHA(repoPath)
+	if err != nil {
+		return GitMeta{}, err
+	}
+	branch, branchErr := getCurrentBranch(repoPath)
+	if branchErr != nil {
+		branch = "" // non-fatal
+	}
+	repo := getGitRemoteURL(repoPath, "origin")
+	return GitMeta{SHA: sha, Branch: branch, Repo: repo}, nil
+}
+
+// pushGitState pushes the current branch to its configured remote tracking branch.
+//
+// It first checks whether HEAD is ahead of the remote tracking ref:
+//   - If ahead: runs "git push" and returns any push error.
+//   - If equal (nothing to push): returns nil immediately.
+//   - If behind or diverged: returns an error — the caller must pull/rebase first.
+//
+// The push uses whatever git credential helper is configured on the host; no
+// credentials are injected by this function.
+func pushGitState(repoPath, branch string) error {
+	if branch == "" || branch == "HEAD" {
+		return errors.New("cannot push: not on a named branch (detached HEAD)")
+	}
+
+	// Fetch the remote tracking state so our comparison is current.
+	fetchCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "fetch", "--prune") //nolint:gosec // repoPath is config-controlled
+	if out, err := fetchCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch failed before push: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+
+	// Determine whether we are ahead of, behind, or equal to the remote.
+	revListCmd := exec.CommandContext( //nolint:gosec // repoPath and branch are config-controlled
+		context.Background(),
+		"git", "-C", repoPath,
+		"rev-list", "--left-right", "--count",
+		"@{u}...HEAD",
+	)
+	out, err := revListCmd.Output()
+	if err != nil {
+		// No upstream tracking branch set — push anyway to origin/<branch>.
+		// This handles the case where the branch has never been pushed.
+		pushCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "push", "origin", branch) //nolint:gosec // repoPath and branch are config-controlled
+		if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
+			return fmt.Errorf("git push failed: %w\n%s", pushErr, strings.TrimSpace(string(pushOut)))
+		}
+		return nil
+	}
+
+	// Parse "behind\tahead" from rev-list output.
+	parts := strings.Fields(strings.TrimSpace(string(out)))
+	if len(parts) != 2 {
+		return fmt.Errorf("unexpected rev-list output: %q", strings.TrimSpace(string(out)))
+	}
+	var behind, ahead int
+	if _, scanErr := fmt.Sscan(parts[0], &behind); scanErr != nil {
+		return fmt.Errorf("parsing rev-list behind count: %w", scanErr)
+	}
+	if _, scanErr := fmt.Sscan(parts[1], &ahead); scanErr != nil {
+		return fmt.Errorf("parsing rev-list ahead count: %w", scanErr)
+	}
+
+	if behind > 0 {
+		return fmt.Errorf(
+			"git-state repo is %d commit(s) behind remote; pull and rebase before deploying (git -C %s pull --rebase)",
+			behind, repoPath,
+		)
+	}
+
+	if ahead == 0 {
+		// Nothing to push — already in sync.
+		return nil
+	}
+
+	// We are ahead: push.
+	pushCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "push") //nolint:gosec // repoPath is config-controlled
+	if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
+		return fmt.Errorf("git push failed: %w\n%s", pushErr, strings.TrimSpace(string(pushOut)))
+	}
+	return nil
+}
+
+// injectGitAnnotations merges git provenance annotations into the metadata.annotations
+// block of every Deployment manifest in mcpManifests. Other manifest kinds are left
+// unchanged. The function modifies mcpManifests in-place; no copy is made.
+//
+// Annotation keys written:
+//
+//	tentacular.io/git-sha    — full HEAD commit SHA
+//	tentacular.io/git-repo   — remote origin URL (empty → key omitted)
+//	tentacular.io/git-branch — branch name (empty → key omitted)
+func injectGitAnnotations(mcpManifests []map[string]any, meta GitMeta) {
+	for _, obj := range mcpManifests {
+		kind, _ := obj["kind"].(string)
+		if kind != "Deployment" {
+			continue
+		}
+
+		// Navigate (and create if absent) metadata.annotations.
+		metadata, ok := obj["metadata"].(map[string]any)
+		if !ok {
+			metadata = make(map[string]any)
+			obj["metadata"] = metadata
+		}
+		annotations, ok := metadata["annotations"].(map[string]any)
+		if !ok {
+			annotations = make(map[string]any)
+			metadata["annotations"] = annotations
+		}
+
+		annotations["tentacular.io/git-sha"] = meta.SHA
+		if meta.Repo != "" {
+			annotations["tentacular.io/git-repo"] = meta.Repo
+		}
+		if meta.Branch != "" {
+			annotations["tentacular.io/git-branch"] = meta.Branch
+		}
+	}
+}

--- a/pkg/cli/deploy_gitstate_test.go
+++ b/pkg/cli/deploy_gitstate_test.go
@@ -1,0 +1,385 @@
+// Tests for git-state deploy helpers: pushGitState, captureGitMeta, and
+// injectGitAnnotations. These tests use real git commands against temporary
+// bare and working repos — no git library mocking is performed.
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupBareAndClone creates a bare "remote" repo and clones it into a working
+// directory. Both directories live in t.TempDir() and are cleaned up
+// automatically. Returns the working clone path.
+func setupBareAndClone(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	bareDir := filepath.Join(base, "remote.git")
+	workDir := filepath.Join(base, "work")
+
+	// Init bare repo
+	runGit(t, "", "init", "--bare", bareDir)
+
+	// Clone into work dir
+	runGit(t, "", "clone", bareDir, workDir)
+
+	// Configure user identity for the work clone (needed for commits)
+	runGit(t, workDir, "config", "user.email", "test@example.com")
+	runGit(t, workDir, "config", "user.name", "Test User")
+
+	// Create an initial commit so the branch exists on the remote
+	initialFile := filepath.Join(workDir, "README")
+	if err := os.WriteFile(initialFile, []byte("init\n"), 0o644); err != nil {
+		t.Fatalf("writing initial file: %v", err)
+	}
+	runGit(t, workDir, "add", ".")
+	runGit(t, workDir, "commit", "-m", "init")
+	runGit(t, workDir, "push", "-u", "origin", "HEAD")
+	return workDir
+}
+
+// runGit runs a git command, optionally in dir, and fails the test on error.
+// Pass dir="" to run in the current directory.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmdArgs := args
+	if dir != "" {
+		cmdArgs = append([]string{"-C", dir}, args...)
+	}
+	cmd := exec.Command("git", cmdArgs...) //nolint:gosec // test helper
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, string(out))
+	}
+}
+
+// addCommit writes a file and commits it in workDir.
+func addCommit(t *testing.T, workDir, filename, content, message string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(workDir, filename), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+	runGit(t, workDir, "add", filename)
+	runGit(t, workDir, "commit", "-m", message)
+}
+
+// --- pushGitState tests ---
+
+// TestPushGitState_AheadPushes verifies that when the working clone has commits
+// not yet on the remote, pushGitState pushes them successfully.
+func TestPushGitState_AheadPushes(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	// Add a local commit that hasn't been pushed.
+	addCommit(t, workDir, "change.txt", "hello\n", "feat: new change")
+
+	branch, branchErr := getCurrentBranch(workDir)
+	if branchErr != nil {
+		t.Fatalf("getCurrentBranch: %v", branchErr)
+	}
+
+	if pushErr := pushGitState(workDir, branch); pushErr != nil {
+		t.Fatalf("pushGitState returned error: %v", pushErr)
+	}
+
+	// Verify the remote now has the commit.
+	sha, shaErr := getCurrentGitSHA(workDir)
+	if shaErr != nil {
+		t.Fatalf("getCurrentGitSHA: %v", shaErr)
+	}
+
+	// Fetch in a second clone to confirm the commit is on the remote.
+	base := t.TempDir()
+	verifyDir := filepath.Join(base, "verify")
+	remoteURL := getGitRemoteURL(workDir, "origin")
+	if remoteURL == "" {
+		t.Fatal("getGitRemoteURL returned empty URL")
+	}
+	runGit(t, "", "clone", remoteURL, verifyDir)
+
+	remoteSHA, remoteSHAErr := getCurrentGitSHA(verifyDir)
+	if remoteSHAErr != nil {
+		t.Fatalf("getCurrentGitSHA on verify clone: %v", remoteSHAErr)
+	}
+	if remoteSHA != sha {
+		t.Errorf("remote SHA %q != local SHA %q after push", remoteSHA, sha)
+	}
+}
+
+// TestPushGitState_EqualIsNoop verifies that when HEAD equals the remote
+// tracking ref (nothing to push), pushGitState returns nil without error.
+func TestPushGitState_EqualIsNoop(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	// Nothing to push — already in sync after setupBareAndClone.
+	branch, err := getCurrentBranch(workDir)
+	if err != nil {
+		t.Fatalf("getCurrentBranch: %v", err)
+	}
+
+	if err := pushGitState(workDir, branch); err != nil {
+		t.Errorf("pushGitState (nothing to push) should return nil, got: %v", err)
+	}
+}
+
+// TestPushGitState_BehindReturnsError verifies that when the remote has commits
+// the local clone doesn't have (diverged/behind), pushGitState returns an error
+// and does not attempt the push.
+func TestPushGitState_BehindReturnsError(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	// Simulate remote advancing: clone a second copy, commit, push.
+	base := t.TempDir()
+	otherDir := filepath.Join(base, "other")
+	remoteURL := getGitRemoteURL(workDir, "origin")
+	runGit(t, "", "clone", remoteURL, otherDir)
+	runGit(t, otherDir, "config", "user.email", "other@example.com")
+	runGit(t, otherDir, "config", "user.name", "Other User")
+	addCommit(t, otherDir, "remote-change.txt", "remote\n", "feat: remote-only change")
+	runGit(t, otherDir, "push")
+
+	// Now workDir is behind — pushGitState should fail.
+	branch, err := getCurrentBranch(workDir)
+	if err != nil {
+		t.Fatalf("getCurrentBranch: %v", err)
+	}
+
+	err = pushGitState(workDir, branch)
+	if err == nil {
+		t.Fatal("expected error when behind remote, got nil")
+	}
+	if !strings.Contains(err.Error(), "behind") {
+		t.Errorf("expected 'behind' in error message, got: %v", err)
+	}
+}
+
+// TestPushGitState_DetachedHeadReturnsError verifies that a detached HEAD state
+// causes pushGitState to return an error rather than silently doing nothing.
+func TestPushGitState_DetachedHeadReturnsError(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	// Detach HEAD
+	sha, _ := getCurrentGitSHA(workDir)
+	runGit(t, workDir, "checkout", "--detach", sha)
+
+	branch, _ := getCurrentBranch(workDir) // will return "HEAD"
+	err := pushGitState(workDir, branch)
+	if err == nil {
+		t.Fatal("expected error for detached HEAD, got nil")
+	}
+}
+
+// --- captureGitMeta tests ---
+
+// TestCaptureGitMeta_PopulatesFields verifies that captureGitMeta returns a
+// non-empty SHA, a non-empty branch name, and a remote URL for a standard clone.
+func TestCaptureGitMeta_PopulatesFields(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	meta, err := captureGitMeta(workDir)
+	if err != nil {
+		t.Fatalf("captureGitMeta: %v", err)
+	}
+	if meta.SHA == "" {
+		t.Error("expected non-empty SHA")
+	}
+	if len(meta.SHA) < 40 {
+		t.Errorf("expected full SHA (>=40 chars), got %q", meta.SHA)
+	}
+	if meta.Branch == "" {
+		t.Error("expected non-empty Branch")
+	}
+	if meta.Repo == "" {
+		t.Error("expected non-empty Repo (remote origin URL)")
+	}
+}
+
+// TestGetCurrentGitSHA_MatchesRevParse verifies getCurrentGitSHA output is a
+// valid full-length commit SHA.
+func TestGetCurrentGitSHA_MatchesRevParse(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	sha, err := getCurrentGitSHA(workDir)
+	if err != nil {
+		t.Fatalf("getCurrentGitSHA: %v", err)
+	}
+	if len(sha) != 40 {
+		t.Errorf("expected 40-char SHA, got %d chars: %q", len(sha), sha)
+	}
+	for _, c := range sha {
+		if ('0' > c || c > '9') && ('a' > c || c > 'f') {
+			t.Errorf("SHA contains non-hex character %q: %q", c, sha)
+			break
+		}
+	}
+}
+
+// --- injectGitAnnotations tests ---
+
+// TestInjectGitAnnotations_InjectsIntoDeployment verifies that the three git
+// annotation keys are added to a Deployment manifest's metadata.annotations.
+func TestInjectGitAnnotations_InjectsIntoDeployment(t *testing.T) {
+	meta := GitMeta{
+		SHA:    "abc1234def567890abc1234def567890abc12345",
+		Repo:   "https://github.com/org/repo",
+		Branch: "main",
+	}
+
+	manifests := []map[string]any{
+		{
+			"kind": "Deployment",
+			"metadata": map[string]any{
+				"name": "my-workflow",
+			},
+		},
+	}
+
+	injectGitAnnotations(manifests, meta)
+
+	metadata, ok := manifests[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("metadata is not a map")
+	}
+	annotations, ok := metadata["annotations"].(map[string]any)
+	if !ok {
+		t.Fatal("annotations is not a map")
+	}
+
+	if annotations["tentacular.io/git-sha"] != meta.SHA {
+		t.Errorf("git-sha: got %q, want %q", annotations["tentacular.io/git-sha"], meta.SHA)
+	}
+	if annotations["tentacular.io/git-repo"] != meta.Repo {
+		t.Errorf("git-repo: got %q, want %q", annotations["tentacular.io/git-repo"], meta.Repo)
+	}
+	if annotations["tentacular.io/git-branch"] != meta.Branch {
+		t.Errorf("git-branch: got %q, want %q", annotations["tentacular.io/git-branch"], meta.Branch)
+	}
+}
+
+// TestInjectGitAnnotations_SkipsNonDeployment verifies that injectGitAnnotations
+// leaves ConfigMap and Service manifests untouched.
+func TestInjectGitAnnotations_SkipsNonDeployment(t *testing.T) {
+	meta := GitMeta{SHA: "abc1234", Repo: "https://example.com/repo", Branch: "main"}
+
+	configMap := map[string]any{
+		"kind":     "ConfigMap",
+		"metadata": map[string]any{"name": "my-workflow-code"},
+	}
+	service := map[string]any{
+		"kind":     "Service",
+		"metadata": map[string]any{"name": "my-workflow"},
+	}
+
+	manifests := []map[string]any{configMap, service}
+	injectGitAnnotations(manifests, meta)
+
+	for _, obj := range manifests {
+		metadata, _ := obj["metadata"].(map[string]any)
+		if annotations, hasAnnotations := metadata["annotations"]; hasAnnotations {
+			t.Errorf("kind %q should not have annotations injected, got: %v", obj["kind"], annotations)
+		}
+	}
+}
+
+// TestInjectGitAnnotations_MergesWithExisting verifies that existing annotations
+// on a Deployment are preserved and the new git keys are added alongside them.
+func TestInjectGitAnnotations_MergesWithExisting(t *testing.T) {
+	meta := GitMeta{SHA: "deadbeef00000000000000000000000000000001", Repo: "", Branch: "feature-x"}
+
+	manifests := []map[string]any{
+		{
+			"kind": "Deployment",
+			"metadata": map[string]any{
+				"name": "my-workflow",
+				"annotations": map[string]any{
+					"tentacular.io/description": "existing annotation",
+				},
+			},
+		},
+	}
+
+	injectGitAnnotations(manifests, meta)
+
+	metadata := manifests[0]["metadata"].(map[string]any)
+	annotations := metadata["annotations"].(map[string]any)
+
+	if annotations["tentacular.io/description"] != "existing annotation" {
+		t.Errorf("existing annotation was overwritten: got %v", annotations["tentacular.io/description"])
+	}
+	if annotations["tentacular.io/git-sha"] != meta.SHA {
+		t.Errorf("git-sha not injected: got %v", annotations["tentacular.io/git-sha"])
+	}
+	// Repo is empty — should not be set
+	if _, hasRepo := annotations["tentacular.io/git-repo"]; hasRepo {
+		t.Error("tentacular.io/git-repo should be omitted when Repo is empty")
+	}
+	if annotations["tentacular.io/git-branch"] != "feature-x" {
+		t.Errorf("git-branch: got %v, want feature-x", annotations["tentacular.io/git-branch"])
+	}
+}
+
+// TestInjectGitAnnotations_CreatesMetadataIfAbsent verifies that a Deployment
+// manifest without a metadata block gets one created rather than panicking.
+func TestInjectGitAnnotations_CreatesMetadataIfAbsent(t *testing.T) {
+	meta := GitMeta{SHA: "abc1234", Branch: "main"}
+
+	manifests := []map[string]any{
+		{"kind": "Deployment"},
+	}
+
+	// Must not panic
+	injectGitAnnotations(manifests, meta)
+
+	metadata, ok := manifests[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("metadata was not created")
+	}
+	annotations, ok := metadata["annotations"].(map[string]any)
+	if !ok {
+		t.Fatal("annotations were not created")
+	}
+	if annotations["tentacular.io/git-sha"] != "abc1234" {
+		t.Errorf("git-sha: got %v", annotations["tentacular.io/git-sha"])
+	}
+}
+
+// TestInjectGitAnnotations_EmptySHAIsNoop verifies that injectGitAnnotations is
+// not called when SHA is empty (the deploy.go guard condition mirrors this).
+func TestInjectGitAnnotations_EmptySHAIsNoop(t *testing.T) {
+	meta := GitMeta{SHA: "", Repo: "https://example.com/repo", Branch: "main"}
+
+	manifests := []map[string]any{
+		{
+			"kind":     "Deployment",
+			"metadata": map[string]any{"name": "my-workflow"},
+		},
+	}
+
+	// Guard mirrors deploy.go: only call injectGitAnnotations when SHA != ""
+	if meta.SHA != "" {
+		injectGitAnnotations(manifests, meta)
+	}
+
+	metadata := manifests[0]["metadata"].(map[string]any)
+	if _, hasAnnotations := metadata["annotations"]; hasAnnotations {
+		t.Error("annotations should not be injected when SHA is empty")
+	}
+}
+
+// --- NewDeployCmd flag tests ---
+
+// TestDeployCmd_NoPushFlagExists verifies the --no-push flag is registered on
+// the deploy command with a default value of false.
+func TestDeployCmd_NoPushFlagExists(t *testing.T) {
+	cmd := NewDeployCmd()
+	f := cmd.Flags().Lookup("no-push")
+	if f == nil {
+		t.Fatal("expected --no-push flag on deploy command")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default false for --no-push, got %q", f.DefValue)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a drift bug where `tntc deploy` would commit locally to the git-state repo but never push to GitHub, causing deployed tentacles to be missing from the remote.

**Option C** from the [git-state integration design](../thekraken/scratch/tntc-gitstate-integration-design.md) — minimal surgical fix. Option A (full rollback semantics, monotonic version enforcement in CLI) is deferred to post-Kraken-deployment.

## Changes

- `pushGitState()`: fetch --prune, check ahead/behind, push if ahead, fail if behind
- `captureGitMeta()`: captures commit SHA, branch, remote URL
- `injectGitAnnotations()`: adds git metadata to Deployment K8s annotations
- `--no-push` flag for emergency bypass (with warning)
- 12 new unit tests with temp bare repos

## Test plan

- [x] Unit tests pass (12 new tests, 1 pre-existing failure unrelated)
- [x] No regressions in other packages
- [ ] Verify real deploy from Kraken pod pushes to GitHub remote
- [ ] Verify Deployment resource has `tentacular.io/git-sha`, `git-repo`, `git-branch` annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)