### PR TITLE
feat(cli): workspace cleanup — explicit enclave, single config, tentacular/ path

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -45,12 +45,12 @@ type TentacularConfig struct {
 	ModuleProxy    ModuleProxyConfig            `yaml:"moduleProxy,omitempty"`
 }
 
-// LoadConfig returns merged config: project > user > defaults.
+// LoadConfig returns the user-level config from ~/.tentacular/config.yaml.
 // Missing files are silently ignored.
 func LoadConfig() TentacularConfig {
 	cfg := TentacularConfig{}
 
-	// 1. Load user-level (~/.tentacular/config.yaml)
+	// Load user-level (~/.tentacular/config.yaml)
 	home, _ := os.UserHomeDir()
 	if home != "" {
 		userPath := filepath.Join(home, ".tentacular", "config.yaml")
@@ -59,124 +59,5 @@ func LoadConfig() TentacularConfig {
 		}
 	}
 
-	// 2. Load project-level (.tentacular/config.yaml) — overrides user
-	projPath := filepath.Join(".tentacular", "config.yaml")
-	if data, err := os.ReadFile(projPath); err == nil { //nolint:gosec // reading project config file
-		var proj TentacularConfig
-		_ = yaml.Unmarshal(data, &proj)
-		mergeConfig(&cfg, &proj)
-	}
-
 	return cfg
-}
-
-func mergeConfig(base, override *TentacularConfig) {
-	if override.Workspace != "" {
-		base.Workspace = override.Workspace
-	}
-	if override.Registry != "" {
-		base.Registry = override.Registry
-	}
-	if override.Namespace != "" {
-		base.Namespace = override.Namespace
-	}
-	if override.RuntimeClass != "" {
-		base.RuntimeClass = override.RuntimeClass
-	}
-	if override.DefaultCluster != "" {
-		base.DefaultCluster = override.DefaultCluster
-	}
-	if len(override.Clusters) > 0 {
-		if base.Clusters == nil {
-			base.Clusters = make(map[string]EnvironmentConfig)
-		}
-		for k, v := range override.Clusters {
-			existing, ok := base.Clusters[k]
-			if !ok {
-				base.Clusters[k] = v
-				continue
-			}
-			mergeEnvConfig(&existing, &v)
-			base.Clusters[k] = existing
-		}
-	}
-	if override.ModuleProxy.Enabled {
-		base.ModuleProxy.Enabled = true
-	}
-	if override.ModuleProxy.Namespace != "" {
-		base.ModuleProxy.Namespace = override.ModuleProxy.Namespace
-	}
-	if override.ModuleProxy.Image != "" {
-		base.ModuleProxy.Image = override.ModuleProxy.Image
-	}
-	if override.ModuleProxy.Storage != "" {
-		base.ModuleProxy.Storage = override.ModuleProxy.Storage
-	}
-	if override.ModuleProxy.PVCSize != "" {
-		base.ModuleProxy.PVCSize = override.ModuleProxy.PVCSize
-	}
-	if override.GitState.Enabled {
-		base.GitState.Enabled = true
-	}
-	if override.GitState.RepoPath != "" {
-		base.GitState.RepoPath = override.GitState.RepoPath
-	}
-	if override.MCP.Endpoint != "" {
-		base.MCP.Endpoint = override.MCP.Endpoint
-	}
-	if override.Catalog.URL != "" {
-		base.Catalog.URL = override.Catalog.URL
-	}
-	if override.Catalog.CacheTTL != "" {
-		base.Catalog.CacheTTL = override.Catalog.CacheTTL
-	}
-	if override.Scaffold.URL != "" {
-		base.Scaffold.URL = override.Scaffold.URL
-	}
-	if override.Scaffold.CacheTTL != "" {
-		base.Scaffold.CacheTTL = override.Scaffold.CacheTTL
-	}
-}
-
-// mergeEnvConfig merges individual fields of an EnvironmentConfig override
-// into a base, preserving base fields that the override does not set.
-func mergeEnvConfig(base, override *EnvironmentConfig) {
-	if override.Context != "" {
-		base.Context = override.Context
-	}
-	if override.Namespace != "" {
-		base.Namespace = override.Namespace
-	}
-	if override.Image != "" {
-		base.Image = override.Image
-	}
-	if override.RuntimeClass != "" {
-		base.RuntimeClass = override.RuntimeClass
-	}
-	if len(override.ConfigOverrides) > 0 {
-		if base.ConfigOverrides == nil {
-			base.ConfigOverrides = make(map[string]any)
-		}
-		for k, v := range override.ConfigOverrides {
-			base.ConfigOverrides[k] = v
-		}
-	}
-	if override.SecretsSource != "" {
-		base.SecretsSource = override.SecretsSource
-	}
-	if override.Enforcement != "" {
-		base.Enforcement = override.Enforcement
-	}
-	if override.MCPEndpoint != "" {
-		base.MCPEndpoint = override.MCPEndpoint
-	}
-	if override.OIDCIssuer != "" {
-		base.OIDCIssuer = override.OIDCIssuer
-	}
-	if override.OIDCClientID != "" {
-		base.OIDCClientID = override.OIDCClientID
-	}
-	if override.OIDCClientSecret != "" {
-		base.OIDCClientSecret = override.OIDCClientSecret
-	}
 }

--- a/pkg/cli/config_env_test.go
+++ b/pkg/cli/config_env_test.go
@@ -178,7 +178,8 @@ func TestLoadEnvironmentNoEnvironmentsDefined(t *testing.T) {
 	}
 }
 
-func TestProjectEnvOverridesUserEnv(t *testing.T) {
+func TestUserEnvIsLoaded(t *testing.T) {
+	// Project-level config is no longer supported. Only user-level config is loaded.
 	origHome := os.Getenv("HOME")
 	tmpHome := t.TempDir()
 	_ = os.Setenv("HOME", tmpHome)
@@ -200,7 +201,7 @@ func TestProjectEnvOverridesUserEnv(t *testing.T) {
 `
 	_ = os.WriteFile(filepath.Join(userDir, "config.yaml"), []byte(userYAML), 0o644)
 
-	// Project-level config overrides dev namespace only
+	// A project-level config is present but should be ignored
 	projDir := filepath.Join(tmpDir, ".tentacular")
 	_ = os.MkdirAll(projDir, 0o755)
 	projYAML := `clusters:
@@ -213,9 +214,9 @@ func TestProjectEnvOverridesUserEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Project should override namespace
-	if env.Namespace != "project-dev-ns" {
-		t.Errorf("expected project-dev-ns, got %s", env.Namespace)
+	// User-level namespace should apply; project-level is ignored
+	if env.Namespace != "user-dev-ns" {
+		t.Errorf("expected user-dev-ns (project-level ignored), got %s", env.Namespace)
 	}
 }
 
@@ -262,32 +263,35 @@ func TestApplyConfigOverridesEmpty(t *testing.T) {
 	}
 }
 
-func TestMergeConfigWithEnvironments(t *testing.T) {
-	base := &TentacularConfig{
-		Registry:  "base-reg",
-		Namespace: "base-ns",
-		Clusters: map[string]EnvironmentConfig{
-			"dev": {Namespace: "base-dev-ns", RuntimeClass: "base-rc"},
-		},
-	}
-	override := &TentacularConfig{
-		Clusters: map[string]EnvironmentConfig{
-			"dev":     {Namespace: "override-dev-ns"},
-			"staging": {Namespace: "staging-ns"},
-		},
-	}
-	mergeConfig(base, override)
+func TestLoadConfigWithMultipleEnvironments(t *testing.T) {
+	// Verify that multiple clusters in user-level config are all loaded.
+	origHome := os.Getenv("HOME")
+	tmpHome := t.TempDir()
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
 
-	if len(base.Clusters) != 2 {
-		t.Errorf("expected 2 environments after merge, got %d", len(base.Clusters))
+	userDir := filepath.Join(tmpHome, ".tentacular")
+	_ = os.MkdirAll(userDir, 0o755)
+	configYAML := `registry: base-reg
+namespace: base-ns
+clusters:
+  dev:
+    namespace: base-dev-ns
+    runtime_class: base-rc
+  staging:
+    namespace: staging-ns
+`
+	_ = os.WriteFile(filepath.Join(userDir, "config.yaml"), []byte(configYAML), 0o644)
+
+	cfg := LoadConfig()
+	if len(cfg.Clusters) != 2 {
+		t.Errorf("expected 2 environments, got %d", len(cfg.Clusters))
 	}
-	// dev environment should be overridden
-	if base.Clusters["dev"].Namespace != "override-dev-ns" {
-		t.Errorf("expected override-dev-ns, got %s", base.Clusters["dev"].Namespace)
+	if cfg.Clusters["dev"].Namespace != "base-dev-ns" {
+		t.Errorf("expected base-dev-ns, got %s", cfg.Clusters["dev"].Namespace)
 	}
-	// staging should be added
-	if base.Clusters["staging"].Namespace != "staging-ns" {
-		t.Errorf("expected staging-ns, got %s", base.Clusters["staging"].Namespace)
+	if cfg.Clusters["staging"].Namespace != "staging-ns" {
+		t.Errorf("expected staging-ns, got %s", cfg.Clusters["staging"].Namespace)
 	}
 }
 

--- a/pkg/cli/config_mcp_test.go
+++ b/pkg/cli/config_mcp_test.go
@@ -32,8 +32,9 @@ clusters:
 	}
 }
 
-// TestMergeConfigDefaultEnv verifies project config overrides user's default_cluster.
-func TestMergeConfigDefaultEnv(t *testing.T) {
+// TestLoadConfigDefaultEnvUserOnly verifies that only user-level default_cluster
+// is loaded; project-level config is ignored.
+func TestLoadConfigDefaultEnvUserOnly(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	tmpHome := t.TempDir()
 	_ = os.Setenv("HOME", tmpHome)
@@ -53,7 +54,7 @@ clusters:
     namespace: dev-ns
 `), 0o644)
 
-	// Project config: overrides default_cluster=staging
+	// Project config is present but should be ignored
 	projDir := filepath.Join(tmpDir, ".tentacular")
 	_ = os.MkdirAll(projDir, 0o755)
 	_ = os.WriteFile(filepath.Join(projDir, "config.yaml"), []byte(`default_cluster: staging
@@ -63,8 +64,9 @@ clusters:
 `), 0o644)
 
 	cfg := LoadConfig()
-	if cfg.DefaultCluster != "staging" {
-		t.Errorf("expected project default_cluster=staging to override user, got %q", cfg.DefaultCluster)
+	// User-level default_cluster should apply; project-level is ignored
+	if cfg.DefaultCluster != "dev" {
+		t.Errorf("expected user default_cluster=dev (project-level ignored), got %q", cfg.DefaultCluster)
 	}
 }
 

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -61,7 +61,8 @@ func TestLoadConfigUserLevel(t *testing.T) {
 	}
 }
 
-func TestLoadConfigProjectOverridesUser(t *testing.T) {
+func TestLoadConfigIgnoresProjectLevel(t *testing.T) {
+	// Project-level config is no longer loaded; only user-level applies.
 	origHome := os.Getenv("HOME")
 	tmpHome := t.TempDir()
 	_ = os.Setenv("HOME", tmpHome)
@@ -77,16 +78,16 @@ func TestLoadConfigProjectOverridesUser(t *testing.T) {
 	_ = os.MkdirAll(userDir, 0o755)
 	_ = os.WriteFile(filepath.Join(userDir, "config.yaml"), []byte("registry: user-registry\nnamespace: user-ns\nruntime_class: user-rc\n"), 0o644)
 
-	// Create project-level config (overrides registry only)
+	// Create project-level config — should NOT be loaded
 	projDir := filepath.Join(tmpDir, ".tentacular")
 	_ = os.MkdirAll(projDir, 0o755)
 	_ = os.WriteFile(filepath.Join(projDir, "config.yaml"), []byte("registry: project-registry\n"), 0o644)
 
 	cfg := LoadConfig()
-	if cfg.Registry != "project-registry" {
-		t.Errorf("expected project-registry, got %s", cfg.Registry)
+	// User-level registry should win; project-level is ignored
+	if cfg.Registry != "user-registry" {
+		t.Errorf("expected user-registry (project-level ignored), got %s", cfg.Registry)
 	}
-	// Namespace and RuntimeClass should come from user config
 	if cfg.Namespace != "user-ns" {
 		t.Errorf("expected user-ns, got %s", cfg.Namespace)
 	}
@@ -95,25 +96,27 @@ func TestLoadConfigProjectOverridesUser(t *testing.T) {
 	}
 }
 
-func TestMergeConfigPartial(t *testing.T) {
-	base := &TentacularConfig{
-		Registry:     "base-reg",
-		Namespace:    "base-ns",
-		RuntimeClass: "base-rc",
+func TestLoadConfigOnlyUserLevel(t *testing.T) {
+	// LoadConfig reads only user-level config; this test verifies that
+	// fields are read correctly and no project-level file is consulted.
+	origHome := os.Getenv("HOME")
+	tmpHome := t.TempDir()
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	userDir := filepath.Join(tmpHome, ".tentacular")
+	_ = os.MkdirAll(userDir, 0o755)
+	_ = os.WriteFile(filepath.Join(userDir, "config.yaml"), []byte("registry: base-reg\nnamespace: base-ns\nruntime_class: base-rc\n"), 0o644)
+
+	cfg := LoadConfig()
+	if cfg.Registry != "base-reg" {
+		t.Errorf("expected base-reg, got %s", cfg.Registry)
 	}
-	override := &TentacularConfig{
-		Registry: "override-reg",
-		// Namespace and RuntimeClass are empty — should not override
+	if cfg.Namespace != "base-ns" {
+		t.Errorf("expected base-ns, got %s", cfg.Namespace)
 	}
-	mergeConfig(base, override)
-	if base.Registry != "override-reg" {
-		t.Errorf("expected override-reg, got %s", base.Registry)
-	}
-	if base.Namespace != "base-ns" {
-		t.Errorf("expected base-ns unchanged, got %s", base.Namespace)
-	}
-	if base.RuntimeClass != "base-rc" {
-		t.Errorf("expected base-rc unchanged, got %s", base.RuntimeClass)
+	if cfg.RuntimeClass != "base-rc" {
+		t.Errorf("expected base-rc, got %s", cfg.RuntimeClass)
 	}
 }
 
@@ -144,30 +147,12 @@ func TestRunConfigureWritesUserConfig(t *testing.T) {
 	}
 }
 
-func TestRunConfigureWritesProjectConfig(t *testing.T) {
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	_ = os.Chdir(tmpDir)
-	defer func() { _ = os.Chdir(origDir) }()
-
+func TestRunConfigureRejectsProjectFlag(t *testing.T) {
+	// --project flag has been removed; configure only writes user-level config.
 	cmd := NewConfigureCmd()
-	cmd.SetArgs([]string{"--default-namespace", "staging", "--project"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("configure --project failed: %v", err)
-	}
-
-	configPath := filepath.Join(tmpDir, ".tentacular", "config.yaml")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("project config file not written: %v", err)
-	}
-
-	var cfg TentacularConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("invalid YAML in project config: %v", err)
-	}
-	if cfg.Namespace != "staging" {
-		t.Errorf("expected namespace staging, got %s", cfg.Namespace)
+	f := cmd.Flags().Lookup("project")
+	if f != nil {
+		t.Error("--project flag should not exist on configure command")
 	}
 }
 

--- a/pkg/cli/configure.go
+++ b/pkg/cli/configure.go
@@ -19,6 +19,8 @@ func NewConfigureCmd() *cobra.Command {
 		Short: "Set default configuration",
 		Long: `Set default configuration values for tntc.
 
+All settings are stored in ~/.tentacular/config.yaml (user-level).
+
 Without --cluster, sets top-level defaults (registry, namespace, runtime-class).
 With --cluster, creates or updates a cluster with OIDC, MCP, and Kubernetes settings.
 
@@ -43,7 +45,6 @@ Examples:
 	cmd.Flags().String("default-namespace", "", "Default Kubernetes namespace")
 	cmd.Flags().String("runtime-class", "", "Default RuntimeClass name")
 	cmd.Flags().String("default-cluster", "", "Set the default cluster name")
-	cmd.Flags().Bool("project", false, "Write to project config (.tentacular/config.yaml) instead of user config")
 
 	// Cluster-scoped flags (require --cluster)
 	cmd.Flags().String("oidc-issuer", "", "OIDC issuer URL (e.g. Keycloak realm URL)")
@@ -59,25 +60,19 @@ Examples:
 }
 
 func runConfigure(cmd *cobra.Command, args []string) error {
-	project, _ := cmd.Flags().GetBool("project")
 	clusterName := flagString(cmd, "cluster")
 	sso, _ := cmd.Flags().GetBool("sso")
 
-	// Determine config file path
-	var configPath string
-	if project {
-		configPath = filepath.Join(".tentacular", "config.yaml")
-	} else {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("determining home directory: %w", err)
-		}
-		configPath = filepath.Join(home, ".tentacular", "config.yaml")
+	// Determine config file path (always user-level)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("determining home directory: %w", err)
 	}
+	configPath := filepath.Join(home, ".tentacular", "config.yaml")
 
 	// Load existing config
 	cfg := TentacularConfig{}
-	if data, err := os.ReadFile(configPath); err == nil { //nolint:gosec // reading config file
+	if data, readErr := os.ReadFile(configPath); readErr == nil { //nolint:gosec // reading config file
 		_ = yaml.Unmarshal(data, &cfg)
 	}
 
@@ -136,10 +131,10 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 
 		// --sso guided flow: prompt for missing OIDC fields
 		if sso {
-			var err error
-			env, err = ssoGuidedSetup(cmd, env)
-			if err != nil {
-				return err
+			var ssoErr error
+			env, ssoErr = ssoGuidedSetup(cmd, env)
+			if ssoErr != nil {
+				return ssoErr
 			}
 		}
 
@@ -147,13 +142,13 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write config
-	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil { //nolint:gosec // non-sensitive config directory
-		return fmt.Errorf("creating config directory: %w", err)
+	if mkdirErr := os.MkdirAll(filepath.Dir(configPath), 0o755); mkdirErr != nil { //nolint:gosec // non-sensitive config directory
+		return fmt.Errorf("creating config directory: %w", mkdirErr)
 	}
 
-	data, err := yaml.Marshal(&cfg)
-	if err != nil {
-		return fmt.Errorf("marshaling config: %w", err)
+	data, marshalErr := yaml.Marshal(&cfg)
+	if marshalErr != nil {
+		return fmt.Errorf("marshaling config: %w", marshalErr)
 	}
 
 	// Determine file permissions: 0o600 if any env has a client secret
@@ -163,8 +158,8 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.OutOrStderr(), "Warning: config contains oidc_client_secret; writing with restricted permissions (0600)")
 	}
 
-	if err := os.WriteFile(configPath, data, perm); err != nil { //nolint:gosec // perm is 0o644 or 0o600 depending on secret presence
-		return fmt.Errorf("writing config: %w", err)
+	if writeErr := os.WriteFile(configPath, data, perm); writeErr != nil { //nolint:gosec // perm is 0o644 or 0o600 depending on secret presence
+		return fmt.Errorf("writing config: %w", writeErr)
 	}
 
 	// Also tighten existing file if permissions are too open

--- a/pkg/cli/configure_test.go
+++ b/pkg/cli/configure_test.go
@@ -297,46 +297,12 @@ func TestConfigure_SecretPresent_FilePermissions0600(t *testing.T) {
 	}
 }
 
-func TestConfigure_ProjectConfig(t *testing.T) {
-	_, cleanup := setupConfigTest(t)
-	defer cleanup()
-
-	// Get the workdir (Chdir'd by setupConfigTest)
-	workdir, _ := os.Getwd()
-
+func TestConfigure_NoProjectFlag(t *testing.T) {
+	// --project flag has been removed; configure always writes user-level config.
 	cmd := NewConfigureCmd()
-	cmd.PersistentFlags().StringP("cluster", "c", "", "Target cluster")
-
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-
-	_ = cmd.Flags().Set("project", "true")
-	_ = cmd.PersistentFlags().Set("cluster", "dev")
-	_ = cmd.Flags().Set("oidc-issuer", "https://auth.example.com/realms/dev")
-	_ = cmd.Flags().Set("oidc-client-id", "devclient")
-
-	if err := cmd.RunE(cmd, nil); err != nil {
-		t.Fatalf("runConfigure --project: %v", err)
-	}
-
-	cfgPath := filepath.Join(workdir, ".tentacular", "config.yaml")
-	data, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("reading project config: %v", err)
-	}
-
-	var cfg TentacularConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parsing project config: %v", err)
-	}
-
-	env, ok := cfg.Clusters["dev"]
-	if !ok {
-		t.Fatal("dev environment not found in project config")
-	}
-	if env.OIDCIssuer != "https://auth.example.com/realms/dev" {
-		t.Errorf("oidc_issuer: got %q", env.OIDCIssuer)
+	f := cmd.Flags().Lookup("project")
+	if f != nil {
+		t.Error("--project flag should not exist on configure command")
 	}
 }
 

--- a/pkg/cli/deploy.go
+++ b/pkg/cli/deploy.go
@@ -141,6 +141,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// Git-state deploy gate: if git-state is enabled, verify the repo is clean
 	// for this enclave/tentacle before proceeding.
 	if cfg.GitState.Enabled && cfg.GitState.RepoPath != "" {
+		if enclaveName == "" {
+			return emitDeployResult(cmd, "fail", "--enclave is required (pass it explicitly)", nil, startedAt)
+		}
 		if gitErr := checkGitStateClean(cfg.GitState.RepoPath, enclaveName, wf.Name); gitErr != nil {
 			return emitDeployResult(cmd, "fail", gitErr.Error(), nil, startedAt)
 		}

--- a/pkg/cli/oidc_test.go
+++ b/pkg/cli/oidc_test.go
@@ -464,13 +464,8 @@ func TestEnvironmentConfig_OIDCFields(t *testing.T) {
 	_ = os.Setenv("HOME", tmpHome)
 	defer func() { _ = os.Setenv("HOME", origHome) }()
 
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	_ = os.Chdir(tmpDir)
-	defer func() { _ = os.Chdir(origDir) }()
-
-	// Write config with OIDC settings
-	configDir := filepath.Join(tmpDir, ".tentacular")
+	// Write config to user-level location
+	configDir := filepath.Join(tmpHome, ".tentacular")
 	_ = os.MkdirAll(configDir, 0o755)
 	configYAML := `clusters:
   staging:

--- a/pkg/cli/profile.go
+++ b/pkg/cli/profile.go
@@ -17,13 +17,8 @@ import (
 
 const profileFreshnessThreshold = time.Hour
 
-// resolveProfileDir returns the envprofiles directory alongside whichever
-// .tentacular/config.yaml is active: project-level (CWD) takes priority,
-// falling back to user-level (~/.tentacular/).
+// resolveProfileDir returns the envprofiles directory under ~/.tentacular/.
 func resolveProfileDir() string {
-	if _, err := os.Stat(filepath.Join(".tentacular", "config.yaml")); err == nil {
-		return filepath.Join(".tentacular", "envprofiles")
-	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".tentacular", "envprofiles") // last resort
@@ -89,7 +84,7 @@ type clusterProfileFn func(ctx context.Context, namespace string) ([]byte, error
 func runProfileAll(profileFn clusterProfileFn, output string, save, force bool) error {
 	cfg := LoadConfig()
 	if len(cfg.Clusters) == 0 {
-		return errors.New("no environments configured in .tentacular/config.yaml")
+		return errors.New("no environments configured in ~/.tentacular/config.yaml")
 	}
 
 	var errs []string

--- a/pkg/cli/scaffold_init.go
+++ b/pkg/cli/scaffold_init.go
@@ -26,8 +26,8 @@ func newScaffoldInitCmd() *cobra.Command {
 	cmd.Flags().String("params-file", "", "Apply parameter values from YAML file to workflow.yaml")
 	cmd.Flags().Bool("no-params", false, "Copy scaffold as-is without printing parameter prompts")
 	cmd.Flags().String("namespace", "", "Set deployment.namespace in workflow.yaml")
-	cmd.Flags().String("dir", "", "Override output directory (default: ~/tentacles/<tentacle-name>/)")
-	cmd.Flags().String("enclave", "", "Target enclave (scopes output to ~/tentacles/<enclave>/<name>/)")
+	cmd.Flags().String("dir", "", "Override output directory (default: ~/tentacular/<tentacle-name>/)")
+	cmd.Flags().String("enclave", "", "Target enclave (required when git-state is enabled; scopes output to ~/tentacular/<enclave>/<name>/)")
 	return cmd
 }
 
@@ -140,7 +140,7 @@ func resolveOutDir(dirOverride, enclaveName, tentacleName string, gitState GitSt
 		return filepath.Join(enclaveDir, tentacleName), nil
 	}
 	if gitState.Enabled {
-		return "", errors.New("git-state is enabled -- --enclave is required")
+		return "", errors.New("--enclave is required (pass it explicitly)")
 	}
 	tentaclesDir, err := scaffold.TentaclesDir()
 	if err != nil {

--- a/pkg/cli/state.go
+++ b/pkg/cli/state.go
@@ -65,7 +65,6 @@ func runStateInit(cmd *cobra.Command, _ []string) error {
 	dirs := []string{
 		filepath.Join(absPath, "enclaves"),
 		filepath.Join(absPath, "archive"),
-		filepath.Join(absPath, ".tentacular"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o700); err != nil {
@@ -80,15 +79,6 @@ func runStateInit(cmd *cobra.Command, _ []string) error {
 			if err := os.WriteFile(keepFile, []byte(""), 0o600); err != nil {
 				return fmt.Errorf("writing %s/.gitkeep: %w", d, err)
 			}
-		}
-	}
-
-	// Write .tentacular/config.yaml with defaults
-	configPath := filepath.Join(absPath, ".tentacular", "config.yaml")
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		configContent := fmt.Sprintf("# Tentacular git-state configuration\ngit_state:\n  repo_path: %s\n  enabled: true\n", absPath)
-		if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
-			return fmt.Errorf("writing .tentacular/config.yaml: %w", err)
 		}
 	}
 
@@ -122,14 +112,18 @@ func runStateInit(cmd *cobra.Command, _ []string) error {
 	// Write README
 	readmePath := filepath.Join(absPath, "README.md")
 	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
-		readmeContent := "# Tentacular Git-State Repository\n\nThis repository tracks tentacle source and metadata managed by `tntc`.\n\n## Structure\n\n- `enclaves/` -- tentacle source organized by enclave\n- `archive/` -- retired tentacles\n- `.tentacular/config.yaml` -- git-state configuration\n\n## Commit Convention\n\nUse [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):\n\n```\nfeat(enclave/tentacle): add initial scaffold\nfix(enclave/tentacle): correct API endpoint\nchore(enclave/tentacle): update secrets reference\n```\n"
+		readmeContent := "# Tentacular Git-State Repository\n\nThis repository tracks tentacle source and metadata managed by `tntc`.\n\n## Structure\n\n- `enclaves/` -- tentacle source organized by enclave\n- `archive/` -- retired tentacles\n\nConfiguration lives in `~/.tentacular/config.yaml` (user-level only).\n\n## Commit Convention\n\nUse [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):\n\n```\nfeat(enclave/tentacle): add initial scaffold\nfix(enclave/tentacle): correct API endpoint\nchore(enclave/tentacle): update secrets reference\n```\n"
 		if err := os.WriteFile(readmePath, []byte(readmeContent), 0o644); err != nil { //nolint:gosec // README is non-sensitive
 			return fmt.Errorf("writing README.md: %w", err)
 		}
 	}
 
 	fmt.Printf("Initialized git-state repo at %s\n", absPath)
-	fmt.Printf("Next: add git_state.repo_path and git_state.enabled: true to ~/.tentacular/config.yaml\n")
+	fmt.Printf("\nNext: add the following to your ~/.tentacular/config.yaml:\n")
+	fmt.Printf("  workspace: %s\n", absPath)
+	fmt.Printf("  git_state:\n")
+	fmt.Printf("    enabled: true\n")
+	fmt.Printf("    repo_path: %s\n", absPath)
 	return nil
 }
 

--- a/pkg/cli/workspace.go
+++ b/pkg/cli/workspace.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -19,10 +21,10 @@ The workspace contains:
   - .secrets/    shared secrets pool
   - .gitignore   ignoring .secrets.yaml, scratch/, .secrets/
 
-The workspace path is written to ~/.tentacular/config.yaml so that
-$shared secret references resolve from this directory.
+The workspace is git-initialized and the path is written to
+~/.tentacular/config.yaml with git_state.enabled: true.
 
-Default path: ~/tentacles`,
+Default path: ~/tentacular`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runInitWorkspace,
 	}
@@ -34,7 +36,7 @@ func runInitWorkspace(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("determining home directory: %w", err)
 	}
 
-	wsPath := filepath.Join(home, "tentacles")
+	wsPath := filepath.Join(home, "tentacular")
 	if len(args) > 0 {
 		wsPath = args[0]
 		wsPath = expandHome(wsPath)
@@ -68,6 +70,19 @@ scratch/
 		}
 	}
 
+	// Initialize git repo if not already one
+	gitInitialized := false
+	gitDir := filepath.Join(absPath, ".git")
+	if _, statErr := os.Stat(gitDir); os.IsNotExist(statErr) {
+		initCmd := exec.CommandContext(context.Background(), "git", "init", absPath) //nolint:gosec // absPath is caller-controlled
+		initCmd.Stdout = os.Stdout
+		initCmd.Stderr = os.Stderr
+		if runErr := initCmd.Run(); runErr != nil {
+			return fmt.Errorf("initializing git repo: %w", runErr)
+		}
+		gitInitialized = true
+	}
+
 	// Write workspace to config
 	configPath := filepath.Join(home, ".tentacular", "config.yaml")
 	cfg := TentacularConfig{}
@@ -76,6 +91,8 @@ scratch/
 	}
 
 	cfg.Workspace = absPath
+	cfg.GitState.Enabled = true
+	cfg.GitState.RepoPath = absPath
 
 	if mkdirErr3 := os.MkdirAll(filepath.Dir(configPath), 0o755); mkdirErr3 != nil { //nolint:gosec // non-sensitive config directory
 		return fmt.Errorf("creating config directory: %w", mkdirErr3)
@@ -92,6 +109,16 @@ scratch/
 	fmt.Printf("Workspace initialized at %s\n", absPath)
 	fmt.Printf("  .secrets/   — shared secrets pool\n")
 	fmt.Printf("  .gitignore  — default ignores\n")
+	if gitInitialized {
+		fmt.Printf("  .git/       — git repository\n")
+	}
 	fmt.Printf("\nWorkspace path written to %s\n", configPath)
+	fmt.Printf("  git_state.enabled: true\n")
+	fmt.Printf("  git_state.repo_path: %s\n", absPath)
+	if gitInitialized {
+		fmt.Printf("\nTo connect a remote:\n")
+		fmt.Printf("  git -C %s remote add origin <url>\n", absPath)
+		fmt.Printf("  git -C %s push -u origin main\n", absPath)
+	}
 	return nil
 }

--- a/pkg/cli/workspace_test.go
+++ b/pkg/cli/workspace_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestInitWorkspaceDefaultPath verifies that the default workspace path is ~/tentacular.
+func TestInitWorkspaceDefaultPath(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	cmd := NewInitWorkspaceCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("init-workspace failed: %v", err)
+	}
+
+	expectedPath := filepath.Join(tmpHome, "tentacular")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected workspace at ~/tentacular (%s): %v", expectedPath, err)
+	}
+
+	// Verify config was written with correct workspace path
+	configPath := filepath.Join(tmpHome, ".tentacular", "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	var cfg TentacularConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("invalid config YAML: %v", err)
+	}
+	if cfg.Workspace != expectedPath {
+		t.Errorf("expected workspace=%s in config, got %s", expectedPath, cfg.Workspace)
+	}
+}
+
+// TestInitWorkspaceCreatesGitRepo verifies that init-workspace runs git init
+// and sets git_state.enabled=true in the config.
+func TestInitWorkspaceCreatesGitRepo(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	cmd := NewInitWorkspaceCmd()
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("init-workspace failed: %v", err)
+	}
+
+	wsPath := filepath.Join(tmpHome, "tentacular")
+
+	// Verify .git directory was created
+	gitDir := filepath.Join(wsPath, ".git")
+	if _, err := os.Stat(gitDir); err != nil {
+		t.Errorf("expected .git directory at %s: %v", gitDir, err)
+	}
+
+	// Verify config has git_state.enabled=true
+	configPath := filepath.Join(tmpHome, ".tentacular", "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	var cfg TentacularConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("invalid config YAML: %v", err)
+	}
+	if !cfg.GitState.Enabled {
+		t.Error("expected git_state.enabled=true in config")
+	}
+	if cfg.GitState.RepoPath != wsPath {
+		t.Errorf("expected git_state.repo_path=%s in config, got %s", wsPath, cfg.GitState.RepoPath)
+	}
+}
+
+// TestInitWorkspaceCustomPath verifies that a custom path arg is respected.
+func TestInitWorkspaceCustomPath(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	customPath := filepath.Join(tmpHome, "my-workspace")
+
+	cmd := NewInitWorkspaceCmd()
+	if err := cmd.RunE(cmd, []string{customPath}); err != nil {
+		t.Fatalf("init-workspace with custom path failed: %v", err)
+	}
+
+	if _, err := os.Stat(customPath); err != nil {
+		t.Errorf("expected workspace at custom path %s: %v", customPath, err)
+	}
+
+	configPath := filepath.Join(tmpHome, ".tentacular", "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config not written: %v", err)
+	}
+	var cfg TentacularConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("invalid config YAML: %v", err)
+	}
+	if cfg.Workspace != customPath {
+		t.Errorf("expected workspace=%s in config, got %s", customPath, cfg.Workspace)
+	}
+}
+
+// TestScaffoldInitRequiresEnclaveWhenGitState verifies that scaffold init
+// returns an error when git_state is enabled and --enclave is not provided.
+func TestScaffoldInitRequiresEnclaveWhenGitState(t *testing.T) {
+	home, _ := scaffoldTestFixture(t, "test-scaffold", "")
+	setTestHome(t, home)
+
+	// Write user config with git_state.enabled=true
+	configDir := filepath.Join(home, ".tentacular")
+	_ = os.MkdirAll(configDir, 0o755)
+	configContent := "git_state:\n  enabled: true\n  repo_path: /tmp/fake-repo\n"
+	_ = os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o644)
+
+	// Call scaffold init WITHOUT --dir and WITHOUT --enclave
+	err := makeScaffoldInitCmd("test-scaffold", "my-tentacle",
+		map[string]string{},
+		map[string]bool{"no-params": true},
+	)
+	if err == nil {
+		t.Fatal("expected error when --enclave not provided with git-state enabled, got nil")
+	}
+	if err.Error() != "--enclave is required (pass it explicitly)" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
+}
+
+// TestLoadConfigUserLevelOnly verifies that LoadConfig only reads
+// ~/.tentacular/config.yaml and ignores any .tentacular/config.yaml in CWD.
+func TestLoadConfigUserLevelOnly(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Write user-level config
+	userDir := filepath.Join(tmpHome, ".tentacular")
+	_ = os.MkdirAll(userDir, 0o755)
+	_ = os.WriteFile(filepath.Join(userDir, "config.yaml"), []byte("registry: user-reg\n"), 0o644)
+
+	// Write project-level config (should be ignored)
+	projDir := filepath.Join(tmpDir, ".tentacular")
+	_ = os.MkdirAll(projDir, 0o755)
+	_ = os.WriteFile(filepath.Join(projDir, "config.yaml"), []byte("registry: project-reg\n"), 0o644)
+
+	cfg := LoadConfig()
+	if cfg.Registry != "user-reg" {
+		t.Errorf("expected user-reg (project-level ignored), got %s", cfg.Registry)
+	}
+}

--- a/pkg/scaffold/discovery.go
+++ b/pkg/scaffold/discovery.go
@@ -79,16 +79,16 @@ func QuickstartsDir() (string, error) {
 	return filepath.Join(home, ".tentacular", "quickstarts"), nil
 }
 
-// TentaclesDir returns ~/tentacles, the canonical tentacle workspace root.
+// TentaclesDir returns ~/tentacular, the canonical tentacle workspace root.
 func TentaclesDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, "tentacles"), nil
+	return filepath.Join(home, "tentacular"), nil
 }
 
-// TentacleDirForEnclave returns ~/tentacles/<enclaveName>, the workspace root
+// TentacleDirForEnclave returns ~/tentacular/<enclaveName>, the workspace root
 // for tentacles belonging to the given enclave.
 func TentacleDirForEnclave(enclaveName string) (string, error) {
 	if enclaveName == "" {

--- a/pkg/scaffold/discovery_test.go
+++ b/pkg/scaffold/discovery_test.go
@@ -595,7 +595,7 @@ func TestEnsurePrivateScaffoldsDirPermissions(t *testing.T) {
 // --- TentacleDirForEnclave ---
 
 // TestTentacleDirForEnclaveValid verifies that a valid enclave name returns
-// the correct path under ~/tentacles/<enclave>.
+// the correct path under ~/tentacular/<enclave>.
 func TestTentacleDirForEnclaveValid(t *testing.T) {
 	tmpHome := t.TempDir()
 	origHome := os.Getenv("HOME")
@@ -606,7 +606,7 @@ func TestTentacleDirForEnclaveValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join(tmpHome, "tentacles", "my-enclave")
+	want := filepath.Join(tmpHome, "tentacular", "my-enclave")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- Default workspace path changed from `~/tentacles/` to `~/tentacular/`
- `tntc init-workspace` now runs `git init`, sets `git_state.enabled: true` in user config, and prints instructions for connecting a remote
- `tntc scaffold init` errors with `--enclave is required (pass it explicitly)` when git-state is enabled and `--enclave` is not provided
- `tntc deploy` errors with `--enclave is required (pass it explicitly)` when git-state is enabled and `--enclave` is not provided
- `LoadConfig` now reads only `~/.tentacular/config.yaml` (user-level); project-level `.tentacular/config.yaml` lookup removed
- `configure --project` flag removed; all configuration writes go to user-level config
- `tntc state init` no longer writes `.tentacular/config.yaml` inside the git-state repo; prints instructions to update `~/.tentacular/config.yaml` instead
- `resolveProfileDir()` in profile.go always uses user-level `~/.tentacular/envprofiles/`
- `mergeConfig` and `mergeEnvConfig` removed (no longer needed without project-level config)

## Test plan

- [x] `TestInitWorkspaceDefaultPath` — default path is `~/tentacular`
- [x] `TestInitWorkspaceCreatesGitRepo` — git repo created, `git_state.enabled=true` in config
- [x] `TestScaffoldInitRequiresEnclaveWhenGitState` — errors when `--enclave` missing
- [x] `TestLoadConfigUserLevelOnly` — project-level config file is ignored
- [x] All pre-existing tests pass (only `TestSharedSecretsE2E_MissingSharedSecretErrors` fails, which is a pre-existing issue)
- [x] `golangci-lint run ./pkg/cli/... ./pkg/scaffold/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)