### PR TITLE
chore: standardize kubeconfig path and gitignore tooling output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ CLAUDE.md
 coverage/
 .cache/
 coverage.out
+
+# tooling output
+.tentacular/envprofiles/
+bin/
+cli.test
+mcp.test

--- a/openspec/changes/per-env-mcp-config/proposal.md
+++ b/openspec/changes/per-env-mcp-config/proposal.md
@@ -39,12 +39,12 @@ reduce friction for users who primarily work against one cluster.
 default_env: dev
 environments:
   dev:
-    kubeconfig: ~/dev-secrets/kubeconfigs/dev.kubeconfig
+    kubeconfig: ~/.kube/configs/dev.kubeconfig
     namespace: tentacular-dev-wf
     mcp_endpoint: http://tentacular-mcp.tentacular-system.svc.cluster.local:8080
     mcp_token_path: ~/.tentacular/tokens/dev-mcp-token
   prod:
-    kubeconfig: ~/dev-secrets/kubeconfigs/prod.kubeconfig
+    kubeconfig: ~/.kube/configs/prod.kubeconfig
     namespace: tentacular-prod-wf
     mcp_endpoint: http://tentacular-mcp.tentacular-system.svc.cluster.local:8080
     mcp_token_path: ~/.tentacular/tokens/prod-mcp-token


### PR DESCRIPTION
## Summary

Pre-rc.10 hygiene:

- Standardize kubeconfig path in `openspec/changes/per-env-mcp-config/proposal.md` from `~/dev-secrets/kubeconfigs/` to `~/.kube/configs/` (matches canonical location).
- Gitignore tooling output: `.tentacular/envprofiles/` (cluster profile cache), `bin/` (local builds), and `*.test` (Go test binaries).

## Test plan

- [ ] CI green
- [ ] No unintended files added (verified `git status` clean post-commit aside from intended openspec drafts)