### PR TITLE
feat(cli): tntc state restore + state status drift detection

### DIFF
--- a/pkg/cli/state.go
+++ b/pkg/cli/state.go
@@ -21,6 +21,7 @@ func NewStateCmd() *cobra.Command {
 	cmd.AddCommand(newStateInitCmd())
 	cmd.AddCommand(newStateStatusCmd())
 	cmd.AddCommand(newStateCommitCmd())
+	cmd.AddCommand(newStateRestoreCmd())
 	return cmd
 }
 
@@ -137,11 +138,15 @@ func newStateStatusCmd() *cobra.Command {
 		RunE:  runStateStatus,
 	}
 	cmd.Flags().Bool("assert-clean", false, "Exit non-zero if there are uncommitted changes in the git-state repo")
+	cmd.Flags().Bool("drift", false, "Report cluster-vs-git drift per tentacle (requires MCP connection)")
+	cmd.Flags().String("enclave", "", "Limit drift report to this enclave (requires --drift)")
 	return cmd
 }
 
 func runStateStatus(cmd *cobra.Command, _ []string) error {
 	assertClean, _ := cmd.Flags().GetBool("assert-clean")
+	driftMode, _ := cmd.Flags().GetBool("drift")
+	enclaveFlagValue, _ := cmd.Flags().GetString("enclave")
 
 	cfg := LoadConfig()
 	if !cfg.GitState.Enabled || cfg.GitState.RepoPath == "" {
@@ -220,6 +225,43 @@ func runStateStatus(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Drift detection: compare cluster annotations vs local git HEAD.
+	if driftMode {
+		if err := runDriftReport(cmd, repoPath, enclaveFlagValue, enclaves); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runDriftReport queries MCP for deployed tentacles and compares their
+// git-sha annotations against local HEAD in the git-state repo.
+func runDriftReport(cmd *cobra.Command, repoPath, enclaveFlagValue string, enclaves []string) error {
+	mcpClient, err := requireMCPClient(cmd)
+	if err != nil {
+		return fmt.Errorf("drift report requires MCP: %w", err)
+	}
+
+	// Filter enclaves if --enclave was specified.
+	targets := enclaves
+	if enclaveFlagValue != "" {
+		targets = []string{enclaveFlagValue}
+	}
+
+	fmt.Printf("\nDrift report:\n")
+	for _, enclave := range targets {
+		entries, driftErr := detectDrift(context.Background(), mcpClient, enclave, repoPath)
+		if driftErr != nil {
+			fmt.Printf("  %s: error querying cluster (%v)\n", enclave, driftErr)
+			continue
+		}
+		if len(entries) == 0 {
+			fmt.Printf("  %s: no deployed tentacles\n", enclave)
+			continue
+		}
+		writeDriftEntries(os.Stdout, entries)
+	}
 	return nil
 }
 

--- a/pkg/cli/state_restore.go
+++ b/pkg/cli/state_restore.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// forwardRevert writes a new commit on the current branch whose tree at
+// <tentacle> matches the tree at <targetSHA>. Returns the new HEAD SHA.
+//
+// If HEAD already matches targetSHA's tree at <tentacle>, no commit is
+// created and the existing HEAD SHA is returned (idempotent).
+//
+// This is NOT a hard reset — prior commits remain reachable in history.
+func forwardRevert(repoPath, tentacle, targetSHA string) (string, error) {
+	headTree, err := gitTreeAt(repoPath, "HEAD", tentacle)
+	if err != nil {
+		return "", fmt.Errorf("read HEAD tree: %w", err)
+	}
+	targetTree, err := gitTreeAt(repoPath, targetSHA, tentacle)
+	if err != nil {
+		return "", fmt.Errorf("read target tree: %w", err)
+	}
+	if headTree == targetTree {
+		// Already at the target tree — idempotent no-op.
+		return gitResolveRef(repoPath, "HEAD")
+	}
+
+	// Check out the target SHA's content for <tentacle> only into the
+	// working tree, then commit on the current branch.
+	if err := gitRun(repoPath, "checkout", targetSHA, "--", tentacle); err != nil {
+		return "", fmt.Errorf("checkout target tree: %w", err)
+	}
+	msg := fmt.Sprintf("revert: restore %s to tree at %s", tentacle, targetSHA[:8])
+	if err := gitRun(repoPath, "add", tentacle); err != nil {
+		return "", fmt.Errorf("stage: %w", err)
+	}
+	if err := gitRun(repoPath, "commit", "-m", msg); err != nil {
+		return "", fmt.Errorf("commit: %w", err)
+	}
+	return gitResolveRef(repoPath, "HEAD")
+}
+
+// gitTreeAt returns the tree object SHA for the given path under ref.
+// e.g. "HEAD:ai-news-digest" returns the blob/tree SHA.
+func gitTreeAt(repoPath, ref, path string) (string, error) {
+	cmd := exec.CommandContext(context.Background(), "git", "rev-parse", ref+":"+path) //nolint:gosec // ref and path are package-controlled
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse %s:%s: %w", ref, path, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitResolveRef resolves a symbolic ref (e.g. "HEAD") to a full SHA.
+func gitResolveRef(repoPath, ref string) (string, error) {
+	cmd := exec.CommandContext(context.Background(), "git", "rev-parse", ref) //nolint:gosec // ref is package-controlled
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse %s: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitRun runs a git command in repoPath, returning any error.
+func gitRun(repoPath string, args ...string) error {
+	cmd := exec.CommandContext(context.Background(), "git", args...) //nolint:gosec // args are controlled by callers in this package
+	cmd.Dir = repoPath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// --- state restore command ---
+
+func newStateRestoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore <name> <ref>",
+		Short: "Restore a tentacle to a prior version and redeploy",
+		Long: `Forward-revert <name>'s tree on the tentacles repo to match <ref>,
+commit the change, and redeploy. Writes a new deploy event.
+
+<ref> is any git ref (SHA, branch, HEAD~N). For idempotent re-deploy
+of the current state, use HEAD.`,
+		Args: cobra.ExactArgs(2),
+		RunE: runStateRestore,
+	}
+	cmd.Flags().String("enclave", "", "Target enclave name (resolves to enclave namespace)")
+	cmd.Flags().Bool("no-push", false, "Skip git push step (emergency bypass; cluster state will diverge from git)")
+	return cmd
+}
+
+func runStateRestore(cmd *cobra.Command, args []string) error {
+	startedAt := time.Now().UTC()
+
+	tentacleName := args[0]
+	ref := args[1]
+
+	enclaveFlagValue, _ := cmd.Flags().GetString("enclave")
+	noPush, _ := cmd.Flags().GetBool("no-push")
+
+	enclaveName, err := resolveEnclaveName(enclaveFlagValue, "")
+	if err != nil {
+		return emitRestoreResult(cmd, "fail", err.Error(), startedAt)
+	}
+
+	cfg := LoadConfig()
+	if !cfg.GitState.Enabled || cfg.GitState.RepoPath == "" {
+		return emitRestoreResult(cmd, "fail", "git-state is not configured; run 'tntc state init --repo-path <path>' first", startedAt)
+	}
+
+	tentaclesRepo := cfg.GitState.RepoPath
+
+	// Tentacle path within the repo: enclaves/<enclave>/<name>/
+	tentaclePath := filepath.Join("enclaves", enclaveName, tentacleName)
+
+	w := StatusWriter(cmd)
+
+	// Step 1: Resolve ref to a full SHA.
+	targetSHA, err := gitResolveRef(tentaclesRepo, ref)
+	if err != nil {
+		return emitRestoreResult(cmd, "fail", fmt.Sprintf("resolve ref %q: %v", ref, err), startedAt)
+	}
+
+	// Step 2: Forward-revert. New commit whose tree matches targetSHA's tree.
+	_, _ = fmt.Fprintf(w, "Restoring %s to tree at %s...\n", tentacleName, targetSHA[:8])
+	newSHA, err := forwardRevert(tentaclesRepo, tentaclePath, targetSHA)
+	if err != nil {
+		return emitRestoreResult(cmd, "fail", fmt.Sprintf("forward-revert: %v", err), startedAt)
+	}
+
+	if newSHA == targetSHA {
+		_, _ = fmt.Fprintf(w, "  Already at target tree — no new commit needed\n")
+	} else {
+		_, _ = fmt.Fprintf(w, "  Committed restore as %s\n", newSHA[:8])
+	}
+
+	// Step 3: Push (unless --no-push).
+	if noPush {
+		_, _ = fmt.Fprintln(w, "WARNING: --no-push bypasses remote sync; cluster state will diverge from git")
+	} else {
+		branch, branchErr := getCurrentBranch(tentaclesRepo)
+		if branchErr != nil {
+			return emitRestoreResult(cmd, "fail", "reading git branch: "+branchErr.Error(), startedAt)
+		}
+		if pushErr := pushGitState(tentaclesRepo, branch); pushErr != nil {
+			return emitRestoreResult(cmd, "fail", "git push failed — restore aborted: "+pushErr.Error(), startedAt)
+		}
+	}
+
+	// Step 4: Deploy. Reuse the existing deploy path.
+	tentacleDir := filepath.Join(tentaclesRepo, tentaclePath)
+
+	mcpClient, err := requireMCPClient(cmd)
+	if err != nil {
+		return emitRestoreResult(cmd, "fail", err.Error(), startedAt)
+	}
+
+	enclaveNS, nsErr := resolveEnclaveNamespace(cmd, mcpClient, enclaveName)
+	if nsErr != nil {
+		return emitRestoreResult(cmd, "fail", nsErr.Error(), startedAt)
+	}
+
+	// Capture git meta for the new commit we just made.
+	gitMeta, metaErr := captureGitMeta(tentaclesRepo)
+	if metaErr != nil {
+		return emitRestoreResult(cmd, "fail", "reading git metadata: "+metaErr.Error(), startedAt)
+	}
+
+	cfg2 := LoadConfig()
+	imageTag := resolveDefaultEngineImage(cfg2)
+
+	deployOpts := InternalDeployOptions{
+		Namespace:    enclaveNS,
+		Image:        imageTag,
+		RuntimeClass: "gvisor",
+		StatusOut:    w,
+		GitMeta:      gitMeta,
+	}
+
+	_, _ = fmt.Fprintf(w, "Deploying restored %s to %s...\n", tentacleName, enclaveNS)
+	_, deployErr := deployWorkflow(tentacleDir, deployOpts, mcpClient)
+	if deployErr != nil {
+		return emitRestoreResult(cmd, "fail", fmt.Sprintf("deploy failed: %v", deployErr), startedAt)
+	}
+
+	summary := fmt.Sprintf("restored %s to tree at %s, redeployed to %s", tentacleName, targetSHA[:8], enclaveNS)
+	return emitRestoreResult(cmd, "pass", summary, startedAt)
+}
+
+func emitRestoreResult(cmd *cobra.Command, status, summary string, startedAt time.Time) error {
+	result := CommandResult{
+		Version: "1",
+		Command: "state restore",
+		Status:  status,
+		Summary: summary,
+		Hints:   []string{},
+		Timing: TimingInfo{
+			StartedAt:  startedAt.Format(time.RFC3339),
+			DurationMs: time.Since(startedAt).Milliseconds(),
+		},
+	}
+	if status == "fail" {
+		result.Hints = append(result.Hints,
+			"check that the ref exists: git -C <repo> log --oneline",
+			"check that the tentacle path exists in the repo at that ref",
+		)
+	}
+
+	if err := EmitResult(cmd, result, os.Stdout); err != nil {
+		return err
+	}
+	if status == "fail" {
+		return fmt.Errorf("%s", summary)
+	}
+	return nil
+}

--- a/pkg/cli/state_restore_test.go
+++ b/pkg/cli/state_restore_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedRepoWith3CommitsTouchingTentacle creates a git repo with 3 commits, each
+// modifying a file inside the named tentacle directory. The repo has a git user
+// configured so commits don't fail in CI.
+func seedRepoWith3CommitsTouchingTentacle(t *testing.T, repoDir, tentacleName string) {
+	t.Helper()
+
+	mustGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	mustGit("init", "-b", "main")
+	mustGit("config", "user.email", "test@example.com")
+	mustGit("config", "user.name", "Test User")
+
+	tentacleDir := filepath.Join(repoDir, tentacleName)
+	if err := os.MkdirAll(tentacleDir, 0o755); err != nil {
+		t.Fatalf("mkdir tentacle: %v", err)
+	}
+
+	for i, content := range []string{"v1 content", "v2 content", "v3 content"} {
+		filePath := filepath.Join(tentacleDir, "workflow.yaml")
+		if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write v%d: %v", i+1, err)
+		}
+		mustGit("add", tentacleName)
+		mustGit("commit", "-m", "chore: v"+[]string{"1", "2", "3"}[i])
+	}
+}
+
+// gitRevParse returns the resolved SHA for the given ref in the given repo.
+func gitRevParse(t *testing.T, repoDir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %s: %v", ref, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitTree returns the tree object SHA for path under the given ref.
+func gitTree(t *testing.T, repoDir, ref, path string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", ref+":"+path)
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %s:%s: %v", ref, path, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitRevReachable returns true if sha appears in the git log (i.e. is reachable from HEAD).
+func gitRevReachable(t *testing.T, repoDir, sha string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "log", "--format=%H")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == sha {
+			return true
+		}
+	}
+	return false
+}
+
+func TestForwardRevertProducesNewCommitMatchingTargetTree(t *testing.T) {
+	repo := t.TempDir()
+	seedRepoWith3CommitsTouchingTentacle(t, repo, "ai-news-digest")
+
+	// Get the SHA of the middle commit (call it v2).
+	v2SHA := gitRevParse(t, repo, "HEAD~1")
+	v3SHA := gitRevParse(t, repo, "HEAD")
+
+	// Forward-revert onto v2's tree.
+	newSHA, err := forwardRevert(repo, "ai-news-digest", v2SHA)
+	if err != nil {
+		t.Fatalf("forwardRevert: %v", err)
+	}
+
+	// Assert: HEAD is no longer v3, and the tree at HEAD matches v2's tree.
+	if gitRevParse(t, repo, "HEAD") == v3SHA {
+		t.Fatal("HEAD did not advance — forward-revert was a no-op")
+	}
+	if gitRevParse(t, repo, "HEAD") != newSHA {
+		t.Fatal("HEAD does not match returned SHA")
+	}
+	headTree := gitTree(t, repo, "HEAD", "ai-news-digest")
+	v2Tree := gitTree(t, repo, v2SHA, "ai-news-digest")
+	if headTree != v2Tree {
+		t.Fatalf("forward-revert tree mismatch:\nHEAD:  %s\nv2:    %s", headTree, v2Tree)
+	}
+}
+
+func TestForwardRevertOnHEADIsIdempotentNoOp(t *testing.T) {
+	repo := t.TempDir()
+	seedRepoWith3CommitsTouchingTentacle(t, repo, "ai-news-digest")
+	headSHA := gitRevParse(t, repo, "HEAD")
+
+	newSHA, err := forwardRevert(repo, "ai-news-digest", headSHA)
+	if err != nil {
+		t.Fatalf("forwardRevert: %v", err)
+	}
+
+	// Idempotent: HEAD already matches target tree, no new commit.
+	if newSHA != headSHA {
+		t.Fatalf("expected no-op (HEAD SHA unchanged), got new SHA %s", newSHA)
+	}
+}
+
+func TestForwardRevertPreservesV3InHistory(t *testing.T) {
+	repo := t.TempDir()
+	seedRepoWith3CommitsTouchingTentacle(t, repo, "ai-news-digest")
+	v3SHA := gitRevParse(t, repo, "HEAD")
+	v2SHA := gitRevParse(t, repo, "HEAD~1")
+
+	if _, err := forwardRevert(repo, "ai-news-digest", v2SHA); err != nil {
+		t.Fatalf("forwardRevert: %v", err)
+	}
+
+	// v3 must still be reachable in git history (not lost via reset).
+	if !gitRevReachable(t, repo, v3SHA) {
+		t.Fatal("v3 SHA was lost — forward-revert used hard reset (BUG)")
+	}
+}

--- a/pkg/cli/state_status.go
+++ b/pkg/cli/state_status.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/randybias/tentacular/pkg/mcp"
+)
+
+// DriftEntry holds the drift comparison result for a single tentacle.
+type DriftEntry struct {
+	Enclave    string `json:"enclave"`
+	Tentacle   string `json:"tentacle"`
+	ClusterSHA string `json:"cluster_sha"`
+	LocalSHA   string `json:"local_sha"`
+	Drifted    bool   `json:"drifted"`
+}
+
+// detectDrift enumerates deployed tentacles for the given enclave via MCP,
+// reads the tentacular.io/git-sha annotation per tentacle, and compares
+// against the HEAD commit SHA of the tentacle's local path in the git-state
+// repo. Returns one DriftEntry per tentacle.
+//
+// MCP errors for individual tentacles are surfaced as drifted entries with
+// ClusterSHA="(unknown)" so that other entries still report correctly.
+func detectDrift(ctx context.Context, mcpClient *mcp.Client, enclave, repoPath string) ([]DriftEntry, error) {
+	wfs, err := mcpClient.WfList(ctx, enclave)
+	if err != nil {
+		return nil, fmt.Errorf("wf_list %s: %w", enclave, err)
+	}
+
+	entries := make([]DriftEntry, 0, len(wfs))
+	for _, wf := range wfs {
+		tentaclePath := filepath.Join("enclaves", enclave, wf.Name)
+
+		// Read the cluster annotation via wf_describe.
+		desc, descErr := mcpClient.WfDescribe(ctx, enclave, wf.Name)
+		clusterSHA := "(unknown)"
+		if descErr == nil && desc != nil {
+			if sha, ok := desc.Annotations["tentacular.io/git-sha"]; ok {
+				clusterSHA = sha
+			}
+		}
+
+		// Read local HEAD SHA for this tentacle in the git-state repo.
+		localSHA := localHeadForPath(ctx, repoPath, tentaclePath)
+
+		drifted := clusterSHA != localSHA || clusterSHA == "(unknown)" || localSHA == "(unknown)"
+
+		entries = append(entries, DriftEntry{
+			Enclave:    enclave,
+			Tentacle:   wf.Name,
+			ClusterSHA: clusterSHA,
+			LocalSHA:   localSHA,
+			Drifted:    drifted,
+		})
+	}
+	return entries, nil
+}
+
+// localHeadForPath resolves the HEAD commit SHA for a path in the git-state
+// repo using `git log -1 --format=%H -- <path>`. Returns "(unknown)" if the
+// path doesn't exist in git history.
+func localHeadForPath(ctx context.Context, repoPath, path string) string {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "log", "-1", "--format=%H", "--", path) //nolint:gosec // repoPath is config-controlled
+	out, err := cmd.Output()
+	if err != nil {
+		return "(unknown)"
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == "" {
+		return "(unknown)"
+	}
+	return sha
+}
+
+// writeDriftEntries writes drift status lines to w in the format:
+//
+//	DRIFT   <enclave>  <tentacle>  cluster=<sha8> local=<sha8>
+//	IN_SYNC <enclave>  <tentacle>  <sha8>
+func writeDriftEntries(w io.Writer, entries []DriftEntry) {
+	for _, e := range entries {
+		if e.Drifted {
+			clusterShort := shortSHA(e.ClusterSHA)
+			localShort := shortSHA(e.LocalSHA)
+			_, _ = fmt.Fprintf(w, "DRIFT\t%s\t%s\tcluster=%s local=%s\n",
+				e.Enclave, e.Tentacle, clusterShort, localShort)
+		} else {
+			_, _ = fmt.Fprintf(w, "IN_SYNC\t%s\t%s\t%s\n",
+				e.Enclave, e.Tentacle, shortSHA(e.ClusterSHA))
+		}
+	}
+}
+
+// shortSHA returns the first 8 chars of a SHA, or the full string if shorter.
+func shortSHA(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
+}

--- a/pkg/cli/state_status_test.go
+++ b/pkg/cli/state_status_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// fixtureWithDrift returns a slice of DriftEntry values where one tentacle
+// has a cluster SHA different from the local SHA.
+func fixtureWithDrift() []DriftEntry {
+	return []DriftEntry{
+		{
+			Enclave:    "tentacular-agensys",
+			Tentacle:   "ai-news-digest",
+			ClusterSHA: "aaa11111",
+			LocalSHA:   "bbb22222",
+			Drifted:    true,
+		},
+		{
+			Enclave:    "tentacular-agensys",
+			Tentacle:   "ai-blog-writer",
+			ClusterSHA: "ccc33333",
+			LocalSHA:   "ccc33333",
+			Drifted:    false,
+		},
+	}
+}
+
+// fixtureInSync returns a slice of DriftEntry values where all tentacles
+// are in sync with the cluster.
+func fixtureInSync() []DriftEntry {
+	return []DriftEntry{
+		{
+			Enclave:    "tentacular-agensys",
+			Tentacle:   "ai-news-digest",
+			ClusterSHA: "ccc33333",
+			LocalSHA:   "ccc33333",
+			Drifted:    false,
+		},
+	}
+}
+
+// renderDriftEntries renders DriftEntry values to a string using the same
+// format as the status command.
+func renderDriftEntries(entries []DriftEntry) string {
+	var buf bytes.Buffer
+	writeDriftEntries(&buf, entries)
+	return buf.String()
+}
+
+func TestStateStatusReportsDriftPerTentacle(t *testing.T) {
+	out := renderDriftEntries(fixtureWithDrift())
+	if !strings.Contains(out, "DRIFT") {
+		t.Fatalf("expected DRIFT marker in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ai-news-digest") {
+		t.Fatal("expected drifted tentacle name in output")
+	}
+	if !strings.Contains(out, "aaa11111") {
+		t.Fatal("expected cluster SHA prefix in output")
+	}
+	if !strings.Contains(out, "bbb22222") {
+		t.Fatal("expected local SHA prefix in output")
+	}
+}
+
+func TestStateStatusReportsInSyncPerTentacle(t *testing.T) {
+	out := renderDriftEntries(fixtureInSync())
+	if !strings.Contains(out, "IN_SYNC") {
+		t.Fatalf("expected IN_SYNC marker in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ai-news-digest") {
+		t.Fatal("expected tentacle name in output")
+	}
+}
+
+func TestStateStatusMixedOutput(t *testing.T) {
+	out := renderDriftEntries(fixtureWithDrift())
+	if !strings.Contains(out, "IN_SYNC") {
+		t.Fatalf("expected IN_SYNC for ai-blog-writer, got:\n%s", out)
+	}
+	if !strings.Contains(out, "DRIFT") {
+		t.Fatalf("expected DRIFT for ai-news-digest, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `tntc state restore <name> <ref>` — forward-revert + redeploy. Writes a new commit on the current branch whose tentacle tree matches the target ref's tree. Prior commits stay reachable in history (not a hard reset). Idempotent when HEAD already matches the target tree.
- Extends `tntc state status --drift` to report cluster-vs-git drift per tentacle. Queries MCP `wf_list` + `wf_describe` for `tentacular.io/git-sha` annotations, compares against local git HEAD. Outputs `DRIFT` / `IN_SYNC` per tentacle. Supports `--enclave` filter.
- Unit tests: 3 forward-revert math tests + 3 drift report tests (all pass).

Implements G1 of the git-state recovery design.
Spec: `thekraken/docs/superpowers/specs/2026-05-05-git-state-recovery-design.md`

## Test plan

- [x] `go test ./pkg/... -run TestForwardRevert` — 3 tests pass
- [x] `go test ./pkg/... -run TestStateStatus` — 3 tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `tntc state restore --help` — usage prints correctly
- [ ] Pre-existing failure: `TestSharedSecretsE2E_MissingSharedSecretErrors` — present on `main` before this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)