### PR TITLE
fix(cli): auto-rebase in pushGitState instead of returning error

### DIFF
--- a/pkg/cli/deploy_gitstate.go
+++ b/pkg/cli/deploy_gitstate.go
@@ -6,9 +6,20 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/randybias/tentacular/pkg/scaffold"
 )
+
+// RebaseConflictError is returned when a git rebase fails due to merge conflicts.
+// The caller must resolve the conflicts manually; the working tree is left clean
+// (rebase aborted) when this error is returned.
+type RebaseConflictError struct {
+	Message string   // human-readable summary
+	Files   []string // conflicted file paths
+}
+
+func (e *RebaseConflictError) Error() string { return e.Message }
 
 // checkGitStateClean verifies the git-state repo has no uncommitted changes
 // for the given enclave/tentacle path.
@@ -65,10 +76,10 @@ func getCurrentBranch(repoPath string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// getGitRemoteURL returns the fetch URL of the given remote (typically "origin").
-// Returns an empty string if the remote is not configured or the command fails.
-func getGitRemoteURL(repoPath, remote string) string {
-	cmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "remote", "get-url", remote) //nolint:gosec // repoPath is config-controlled
+// getGitRemoteURL returns the fetch URL of the "origin" remote.
+// Returns an empty string if origin is not configured or the command fails.
+func getGitRemoteURL(repoPath string) string {
+	cmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "remote", "get-url", "origin") //nolint:gosec // repoPath is config-controlled
 	out, err := cmd.Output()
 	if err != nil {
 		// Remote may not be configured — return empty string silently.
@@ -89,16 +100,21 @@ func captureGitMeta(repoPath string) (GitMeta, error) {
 	if branchErr != nil {
 		branch = "" // non-fatal
 	}
-	repo := getGitRemoteURL(repoPath, "origin")
+	repo := getGitRemoteURL(repoPath)
 	return GitMeta{SHA: sha, Branch: branch, Repo: repo}, nil
 }
 
 // pushGitState pushes the current branch to its configured remote tracking branch.
 //
-// It first checks whether HEAD is ahead of the remote tracking ref:
-//   - If ahead: runs "git push" and returns any push error.
-//   - If equal (nothing to push): returns nil immediately.
-//   - If behind or diverged: returns an error — the caller must pull/rebase first.
+// Behavior by remote comparison state:
+//   - Equal: no-op, returns nil.
+//   - Ahead: pushes immediately.
+//   - Behind or diverged: rebases onto origin/<branch> first, then pushes.
+//     A real merge conflict aborts the rebase and returns *RebaseConflictError.
+//   - No upstream set: pushes to origin/<branch> directly.
+//
+// Push races (non-fast-forward rejection) trigger a fetch+rebase+retry loop
+// with exponential backoff (250ms, 500ms, 1s), up to 3 total attempts.
 //
 // The push uses whatever git credential helper is configured on the host; no
 // credentials are injected by this function.
@@ -107,61 +123,142 @@ func pushGitState(repoPath, branch string) error {
 		return errors.New("cannot push: not on a named branch (detached HEAD)")
 	}
 
-	// Fetch the remote tracking state so our comparison is current.
-	fetchCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "fetch", "--prune") //nolint:gosec // repoPath is config-controlled
-	if out, err := fetchCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git fetch failed before push: %w\n%s", err, strings.TrimSpace(string(out)))
-	}
+	const maxAttempts = 3
+	backoff := []time.Duration{250 * time.Millisecond, 500 * time.Millisecond, time.Second}
 
-	// Determine whether we are ahead of, behind, or equal to the remote.
-	revListCmd := exec.CommandContext( //nolint:gosec // repoPath and branch are config-controlled
-		context.Background(),
-		"git", "-C", repoPath,
-		"rev-list", "--left-right", "--count",
-		"@{u}...HEAD",
-	)
-	out, err := revListCmd.Output()
-	if err != nil {
-		// No upstream tracking branch set — push anyway to origin/<branch>.
-		// This handles the case where the branch has never been pushed.
-		pushCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "push", "origin", branch) //nolint:gosec // repoPath and branch are config-controlled
-		if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
-			return fmt.Errorf("git push failed: %w\n%s", pushErr, strings.TrimSpace(string(pushOut)))
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			time.Sleep(backoff[attempt-1])
 		}
-		return nil
-	}
 
-	// Parse "behind\tahead" from rev-list output.
-	parts := strings.Fields(strings.TrimSpace(string(out)))
-	if len(parts) != 2 {
-		return fmt.Errorf("unexpected rev-list output: %q", strings.TrimSpace(string(out)))
-	}
-	var behind, ahead int
-	if _, scanErr := fmt.Sscan(parts[0], &behind); scanErr != nil {
-		return fmt.Errorf("parsing rev-list behind count: %w", scanErr)
-	}
-	if _, scanErr := fmt.Sscan(parts[1], &ahead); scanErr != nil {
-		return fmt.Errorf("parsing rev-list ahead count: %w", scanErr)
-	}
+		// Fetch the remote tracking state so our comparison is current.
+		fetchCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "fetch", "--prune") //nolint:gosec // repoPath is config-controlled
+		if fetchOut, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+			return fmt.Errorf("git fetch failed before push: %w\n%s", fetchErr, strings.TrimSpace(string(fetchOut)))
+		}
 
-	if behind > 0 {
-		return fmt.Errorf(
-			"git-state repo is %d commit(s) behind remote; pull and rebase before deploying (git -C %s pull --rebase)",
-			behind, repoPath,
+		// Determine whether we are ahead of, behind, or equal to the remote.
+		revListCmd := exec.CommandContext( //nolint:gosec // repoPath and branch are config-controlled
+			context.Background(),
+			"git", "-C", repoPath,
+			"rev-list", "--left-right", "--count",
+			"@{u}...HEAD",
 		)
-	}
+		out, revErr := revListCmd.Output()
+		if revErr != nil {
+			// No upstream tracking branch set — push to origin/<branch>.
+			// This handles the case where the branch has never been pushed.
+			pushCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "push", "origin", branch) //nolint:gosec // repoPath and branch are config-controlled
+			if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
+				return fmt.Errorf("git push failed: %w\n%s", pushErr, strings.TrimSpace(string(pushOut)))
+			}
+			return nil
+		}
 
-	if ahead == 0 {
-		// Nothing to push — already in sync.
-		return nil
-	}
+		// Parse "behind\tahead" from rev-list output.
+		parts := strings.Fields(strings.TrimSpace(string(out)))
+		if len(parts) != 2 {
+			return fmt.Errorf("unexpected rev-list output: %q", strings.TrimSpace(string(out)))
+		}
+		var behind, ahead int
+		if _, scanErr := fmt.Sscan(parts[0], &behind); scanErr != nil {
+			return fmt.Errorf("parsing rev-list behind count: %w", scanErr)
+		}
+		if _, scanErr := fmt.Sscan(parts[1], &ahead); scanErr != nil {
+			return fmt.Errorf("parsing rev-list ahead count: %w", scanErr)
+		}
 
-	// We are ahead: push.
-	pushCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "push") //nolint:gosec // repoPath is config-controlled
-	if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
+		if behind > 0 {
+			// Auto-rebase onto the remote branch.
+			if rebaseErr := rebaseOntoRemote(repoPath, branch); rebaseErr != nil {
+				return rebaseErr
+			}
+			// After rebase, loop back to re-fetch and re-check before pushing.
+			continue
+		}
+
+		if ahead == 0 {
+			// Nothing to push — already in sync.
+			return nil
+		}
+
+		// We are ahead: push.
+		pushCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "push") //nolint:gosec // repoPath is config-controlled
+		pushOut, pushErr := pushCmd.CombinedOutput()
+		if pushErr == nil {
+			return nil
+		}
+
+		// If this is a non-fast-forward rejection, retry (push race).
+		if isNonFastForward(string(pushOut)) && attempt < maxAttempts-1 {
+			continue
+		}
 		return fmt.Errorf("git push failed: %w\n%s", pushErr, strings.TrimSpace(string(pushOut)))
 	}
-	return nil
+
+	return fmt.Errorf("git push failed after %d attempts: remote continues to reject (non-fast-forward)", maxAttempts)
+}
+
+// rebaseOntoRemote runs "git rebase origin/<branch>" in repoPath.
+// On conflict it aborts the rebase and returns *RebaseConflictError.
+func rebaseOntoRemote(repoPath, branch string) error {
+	upstream := "origin/" + branch
+	rebaseCmd := exec.CommandContext( //nolint:gosec // repoPath and branch are config-controlled
+		context.Background(),
+		"git", "-C", repoPath, "rebase", upstream,
+	)
+	rebaseOut, rebaseErr := rebaseCmd.CombinedOutput()
+	if rebaseErr == nil {
+		return nil
+	}
+
+	// Rebase failed — collect conflicted files and abort.
+	conflictFiles := collectConflictedFiles(repoPath)
+
+	// Abort the rebase to leave the working tree clean.
+	abortCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "rebase", "--abort") //nolint:gosec // repoPath is config-controlled
+	_ = abortCmd.Run()                                                                                // best-effort
+
+	if len(conflictFiles) > 0 {
+		return &RebaseConflictError{
+			Files:   conflictFiles,
+			Message: fmt.Sprintf("rebase conflict on %d file(s): %s; rebase aborted — resolve conflicts and redeploy", len(conflictFiles), strings.Join(conflictFiles, ", ")),
+		}
+	}
+
+	// Generic rebase failure (non-conflict, e.g. network error during patch apply).
+	return fmt.Errorf("git rebase %s failed: %w\n%s", upstream, rebaseErr, strings.TrimSpace(string(rebaseOut)))
+}
+
+// collectConflictedFiles returns the list of paths that are in a conflicted
+// state in the working tree (UU/AA/DD markers in git status --porcelain).
+func collectConflictedFiles(repoPath string) []string {
+	statusCmd := exec.CommandContext(context.Background(), "git", "-C", repoPath, "status", "--porcelain") //nolint:gosec // repoPath is config-controlled
+	out, err := statusCmd.Output()
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if len(line) < 3 {
+			continue
+		}
+		xy := line[:2]
+		// Conflict markers: UU, AA, DD, AU, UA, DU, UD
+		if strings.ContainsAny(string(xy[0]), "UAD") && strings.ContainsAny(string(xy[1]), "UAD") && xy != "  " {
+			files = append(files, strings.TrimSpace(line[3:]))
+		}
+	}
+	return files
+}
+
+// isNonFastForward returns true when the git push output indicates a
+// non-fast-forward rejection (i.e. someone pushed between our fetch and push).
+func isNonFastForward(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "non-fast-forward") ||
+		strings.Contains(lower, "rejected") ||
+		strings.Contains(lower, "[rejected]")
 }
 
 // injectGitAnnotations merges git provenance annotations into the metadata.annotations

--- a/pkg/cli/deploy_gitstate_test.go
+++ b/pkg/cli/deploy_gitstate_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,7 +95,7 @@ func TestPushGitState_AheadPushes(t *testing.T) {
 	// Fetch in a second clone to confirm the commit is on the remote.
 	base := t.TempDir()
 	verifyDir := filepath.Join(base, "verify")
-	remoteURL := getGitRemoteURL(workDir, "origin")
+	remoteURL := getGitRemoteURL(workDir)
 	if remoteURL == "" {
 		t.Fatal("getGitRemoteURL returned empty URL")
 	}
@@ -125,35 +126,59 @@ func TestPushGitState_EqualIsNoop(t *testing.T) {
 	}
 }
 
-// TestPushGitState_BehindReturnsError verifies that when the remote has commits
-// the local clone doesn't have (diverged/behind), pushGitState returns an error
-// and does not attempt the push.
-func TestPushGitState_BehindReturnsError(t *testing.T) {
+// TestPushGitState_BehindRebases verifies that when the remote has commits the
+// local clone doesn't have (strict behind, no local commits), pushGitState
+// auto-rebases and successfully pushes.
+func TestPushGitState_BehindRebases(t *testing.T) {
 	workDir := setupBareAndClone(t)
 
 	// Simulate remote advancing: clone a second copy, commit, push.
 	base := t.TempDir()
 	otherDir := filepath.Join(base, "other")
-	remoteURL := getGitRemoteURL(workDir, "origin")
+	remoteURL := getGitRemoteURL(workDir)
 	runGit(t, "", "clone", remoteURL, otherDir)
 	runGit(t, otherDir, "config", "user.email", "other@example.com")
 	runGit(t, otherDir, "config", "user.name", "Other User")
 	addCommit(t, otherDir, "remote-change.txt", "remote\n", "feat: remote-only change")
 	runGit(t, otherDir, "push")
 
-	// Now workDir is behind — pushGitState should fail.
+	// Now workDir is behind. Also add a local commit (diverged case).
+	addCommit(t, workDir, "local-change.txt", "local\n", "feat: local change")
+
 	branch, err := getCurrentBranch(workDir)
 	if err != nil {
 		t.Fatalf("getCurrentBranch: %v", err)
 	}
 
-	err = pushGitState(workDir, branch)
-	if err == nil {
-		t.Fatal("expected error when behind remote, got nil")
+	// pushGitState should rebase and push successfully.
+	if pushErr := pushGitState(workDir, branch); pushErr != nil {
+		t.Fatalf("pushGitState should succeed after auto-rebase, got: %v", pushErr)
 	}
-	if !strings.Contains(err.Error(), "behind") {
-		t.Errorf("expected 'behind' in error message, got: %v", err)
+
+	// Verify the remote now has both commits (the remote-only and the local).
+	verifyBase := t.TempDir()
+	verifyDir := filepath.Join(verifyBase, "verify")
+	runGit(t, "", "clone", remoteURL, verifyDir)
+
+	verifyLog := runGitOutput(t, verifyDir, "log", "--oneline")
+	if !strings.Contains(verifyLog, "feat: remote-only change") {
+		t.Errorf("expected remote-only change in log: %s", verifyLog)
 	}
+	if !strings.Contains(verifyLog, "feat: local change") {
+		t.Errorf("expected local change in log: %s", verifyLog)
+	}
+}
+
+// runGitOutput runs a git command and returns its combined stdout output.
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", cmdArgs...) //nolint:gosec // test helper
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, string(out))
+	}
+	return string(out)
 }
 
 // TestPushGitState_DetachedHeadReturnsError verifies that a detached HEAD state
@@ -366,6 +391,149 @@ func TestInjectGitAnnotations_EmptySHAIsNoop(t *testing.T) {
 	metadata := manifests[0]["metadata"].(map[string]any)
 	if _, hasAnnotations := metadata["annotations"]; hasAnnotations {
 		t.Error("annotations should not be injected when SHA is empty")
+	}
+}
+
+// TestPushGitState_RebaseConflictAbortsCleanly verifies that when origin has a
+// conflicting change to the same file and line, pushGitState returns a
+// *RebaseConflictError and leaves the working tree clean (no rebase-in-progress
+// markers).
+func TestPushGitState_RebaseConflictAbortsCleanly(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	// Write a shared file to origin via a second clone.
+	base := t.TempDir()
+	otherDir := filepath.Join(base, "other")
+	remoteURL := getGitRemoteURL(workDir)
+	runGit(t, "", "clone", remoteURL, otherDir)
+	runGit(t, otherDir, "config", "user.email", "other@example.com")
+	runGit(t, otherDir, "config", "user.name", "Other User")
+	addCommit(t, otherDir, "conflict.txt", "remote version\n", "feat: remote version")
+	runGit(t, otherDir, "push")
+
+	// Local clone makes a conflicting change to the same file.
+	addCommit(t, workDir, "conflict.txt", "local version\n", "feat: local version")
+
+	branch, err := getCurrentBranch(workDir)
+	if err != nil {
+		t.Fatalf("getCurrentBranch: %v", err)
+	}
+
+	pushErr := pushGitState(workDir, branch)
+	if pushErr == nil {
+		t.Fatal("expected RebaseConflictError, got nil")
+	}
+
+	var conflictErr *RebaseConflictError
+	if !errors.As(pushErr, &conflictErr) {
+		t.Fatalf("expected *RebaseConflictError, got %T: %v", pushErr, pushErr)
+	}
+	if len(conflictErr.Files) == 0 {
+		t.Error("expected at least one conflicted file path")
+	}
+	found := false
+	for _, f := range conflictErr.Files {
+		if strings.Contains(f, "conflict.txt") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected conflict.txt in conflicted files, got: %v", conflictErr.Files)
+	}
+
+	// Working tree must be clean — no rebase-in-progress markers.
+	statusCmd := exec.Command("git", "-C", workDir, "status", "--porcelain") //nolint:gosec // test
+	statusOut, statusCmdErr := statusCmd.CombinedOutput()
+	if statusCmdErr != nil {
+		t.Fatalf("git status: %v\n%s", statusCmdErr, string(statusOut))
+	}
+	// Confirm no "MERGE_HEAD" or "rebase-merge" directory exists.
+	rebaseMergeDir := filepath.Join(workDir, ".git", "rebase-merge")
+	if _, statErr := os.Stat(rebaseMergeDir); statErr == nil {
+		t.Error("rebase-merge directory still present — rebase was not aborted cleanly")
+	}
+	rebaseApplyDir := filepath.Join(workDir, ".git", "rebase-apply")
+	if _, statErr := os.Stat(rebaseApplyDir); statErr == nil {
+		t.Error("rebase-apply directory still present — rebase was not aborted cleanly")
+	}
+}
+
+// TestPushGitState_RetryExhaustedError verifies that after 3 push attempts the
+// function returns an error. We install a pre-receive hook on the bare repo
+// that always rejects pushes with a non-fast-forward message, so every attempt
+// fails regardless of the state of the local branch.
+func TestPushGitState_RetryExhaustedError(t *testing.T) {
+	workDir := setupBareAndClone(t)
+	remoteURL := getGitRemoteURL(workDir)
+
+	// Install a pre-receive hook that always rejects with a non-fast-forward msg.
+	hooksDir := filepath.Join(remoteURL, "hooks")
+	hookPath := filepath.Join(hooksDir, "pre-receive")
+	hookScript := "#!/bin/sh\necho '[rejected] non-fast-forward' >&2\nexit 1\n"
+	if err := os.WriteFile(hookPath, []byte(hookScript), 0o755); err != nil {
+		t.Fatalf("writing pre-receive hook: %v", err)
+	}
+
+	// Add a local commit so we have something to push.
+	addCommit(t, workDir, "local.txt", "local\n", "feat: local")
+
+	branch, err := getCurrentBranch(workDir)
+	if err != nil {
+		t.Fatalf("getCurrentBranch: %v", err)
+	}
+
+	pushErr := pushGitState(workDir, branch)
+	if pushErr == nil {
+		t.Fatal("expected error after retry exhaustion, got nil")
+	}
+	// Must not be a rebase conflict — this is a push rejection.
+	var conflictErr *RebaseConflictError
+	if errors.As(pushErr, &conflictErr) {
+		t.Errorf("expected push-exhausted error, got RebaseConflictError: %v", pushErr)
+	}
+	t.Logf("got expected error: %v", pushErr)
+}
+
+// TestPushGitState_CleanRebaseAndPush verifies the core auto-rebase scenario:
+// origin has one commit, local has one non-conflicting commit. pushGitState must
+// rebase and push, resulting in a remote that contains both commits.
+func TestPushGitState_CleanRebaseAndPush(t *testing.T) {
+	workDir := setupBareAndClone(t)
+
+	// Remote advances via a second clone.
+	base := t.TempDir()
+	otherDir := filepath.Join(base, "other")
+	remoteURL := getGitRemoteURL(workDir)
+	runGit(t, "", "clone", remoteURL, otherDir)
+	runGit(t, otherDir, "config", "user.email", "other@example.com")
+	runGit(t, otherDir, "config", "user.name", "Other User")
+	addCommit(t, otherDir, "upstream.txt", "upstream content\n", "feat: upstream commit")
+	runGit(t, otherDir, "push")
+
+	// Local has a non-conflicting commit on a different file.
+	addCommit(t, workDir, "local.txt", "local content\n", "feat: local commit")
+
+	branch, branchErr := getCurrentBranch(workDir)
+	if branchErr != nil {
+		t.Fatalf("getCurrentBranch: %v", branchErr)
+	}
+
+	if pushErr := pushGitState(workDir, branch); pushErr != nil {
+		t.Fatalf("expected clean rebase+push to succeed, got: %v", pushErr)
+	}
+
+	// Verify the remote has both commits.
+	verifyBase := t.TempDir()
+	verifyDir := filepath.Join(verifyBase, "verify")
+	runGit(t, "", "clone", remoteURL, verifyDir)
+	log := runGitOutput(t, verifyDir, "log", "--oneline")
+
+	if !strings.Contains(log, "feat: upstream commit") {
+		t.Errorf("upstream commit missing from remote log: %s", log)
+	}
+	if !strings.Contains(log, "feat: local commit") {
+		t.Errorf("local commit missing from remote log: %s", log)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `pushGitState` now auto-rebases onto `origin/<branch>` when the local branch is behind or diverged, instead of returning an error requiring manual intervention
- On clean rebase, push proceeds normally; on conflict, rebase is aborted and `*RebaseConflictError` is returned with the list of conflicted file paths
- Push races (non-fast-forward rejection) are retried up to 3 times with exponential backoff (250ms, 500ms, 1s)
- `getGitRemoteURL` signature simplified: dropped unused `remote` parameter (always "origin")

Closes #133

## Test plan

- [x] `TestPushGitState_AheadPushes` — ahead-only: push goes through (pre-existing, kept)
- [x] `TestPushGitState_EqualIsNoop` — nothing to push: no-op (pre-existing, kept)
- [x] `TestPushGitState_BehindRebases` — was `BehindReturnsError`; now verifies clean rebase+push with diverged commits on separate files
- [x] `TestPushGitState_CleanRebaseAndPush` — new: core diverged scenario (origin+1, local+1 different files), remote has both commits after push
- [x] `TestPushGitState_RebaseConflictAbortsCleanly` — new: conflicting change to same file returns `*RebaseConflictError`, no `rebase-merge` dir left behind
- [x] `TestPushGitState_RetryExhaustedError` — new: pre-receive hook that always rejects; after 3 attempts returns error, not `RebaseConflictError`
- [x] `TestPushGitState_DetachedHeadReturnsError` — detached HEAD guard (pre-existing, kept)
- [x] `go test ./pkg/...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)